### PR TITLE
A0-330: Add transaction finalized pop-up

### DIFF
--- a/packages/react-signer/src/util.ts
+++ b/packages/react-signer/src/util.ts
@@ -100,7 +100,7 @@ export function handleTxResults (handler: 'send' | 'signAndSend', queueSetTxStat
       txFailedCb(result);
     }
 
-    if (result.isCompleted) {
+    if (result.isFinalized) {
       unsubscribe();
     }
   };


### PR DESCRIPTION
After this PR at first we get:
![Screenshot from 2021-08-30 16-39-12](https://user-images.githubusercontent.com/22624476/131357189-c6616f18-156a-49c5-b4fa-0b01d2948f20.png)
And after the block is finalized:
![Screenshot from 2021-08-30 16-39-15](https://user-images.githubusercontent.com/22624476/131357203-53ffcd5e-cc4c-42a3-acbb-0f3a6586b94e.png)
