### PR TITLE
AZ-580 Removed Ideal Staked, Staked and Inlfation widgets from Staking/Overiew tab

### DIFF
--- a/packages/page-staking/src/Overview/Summary.tsx
+++ b/packages/page-staking/src/Overview/Summary.tsx
@@ -21,7 +21,7 @@ interface Props {
   targets: SortedTargets;
 }
 
-function Summary ({ className = '', isVisible, stakingOverview, targets: { counterForNominators, inflation: { idealStake, inflation, stakedFraction }, nominators, waitingIds } }: Props): React.ReactElement<Props> {
+function Summary ({ className = '', isVisible, stakingOverview, targets: { counterForNominators, nominators, waitingIds } }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
 
   return (
@@ -62,32 +62,6 @@ function Summary ({ className = '', isVisible, stakingOverview, targets: { count
             : <Spinner noLabel />
           }
         </CardSummary>
-      </section>
-      <section>
-        {(idealStake > 0) && Number.isFinite(idealStake) && (
-          <CardSummary
-            className='media--1400'
-            label={t<string>('ideal staked')}
-          >
-            <>{(idealStake * 100).toFixed(1)}%</>
-          </CardSummary>
-        )}
-        {(stakedFraction > 0) && (
-          <CardSummary
-            className='media--1300'
-            label={t<string>('staked')}
-          >
-            <>{(stakedFraction * 100).toFixed(1)}%</>
-          </CardSummary>
-        )}
-        {(inflation > 0) && Number.isFinite(inflation) && (
-          <CardSummary
-            className='media--1200'
-            label={t<string>('inflation')}
-          >
-            <>{inflation.toFixed(1)}%</>
-          </CardSummary>
-        )}
       </section>
       <section>
         <SummarySession />


### PR DESCRIPTION
Testing done:
* `yarn install`,
* `yarn build`,
* `yarn run test`,
* `yarn start` 
Result is that those widgets are removed:
![image](https://user-images.githubusercontent.com/3909333/155982322-03ec0b3b-baf3-4619-ad24-4e4609dd60d5.png)
