### PR TITLE
A0-955 Hide points column in Staking Overview tab

### DIFF
--- a/packages/page-staking/src/Validators/Address/index.tsx
+++ b/packages/page-staking/src/Validators/Address/index.tsx
@@ -87,7 +87,7 @@ function useAddressCalls (api: ApiPromise, address: string, isMain?: boolean) {
   return { accountInfo, slashingSpans };
 }
 
-function Address ({ address, className = '', filterName, hasQueries, isElected, isFavorite, isMain, isPara, lastBlock, minCommission, nominatedBy, points, recentlyOnline, toggleFavorite, validatorInfo, withIdentity }: Props): React.ReactElement<Props> | null {
+function Address ({ address, className = '', filterName, hasQueries, isElected, isFavorite, isMain, isPara, lastBlock, minCommission, nominatedBy, recentlyOnline, toggleFavorite, validatorInfo, withIdentity }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
   const { accountInfo, slashingSpans } = useAddressCalls(api, address, isMain);
 
@@ -160,9 +160,6 @@ function Address ({ address, className = '', filterName, hasQueries, isElected, 
       </td>
       {isMain && (
         <>
-          <td className='number'>
-            {points}
-          </td>
           <td className='number'>
             {lastBlock}
           </td>

--- a/packages/page-staking/src/Validators/CurrentList.tsx
+++ b/packages/page-staking/src/Validators/CurrentList.tsx
@@ -95,7 +95,7 @@ const DEFAULT_PARAS = {};
 function CurrentList ({ className, favorites, hasQueries, isIntentions, isOwn, minCommission, nominatedBy, ownStashIds, paraValidators = DEFAULT_PARAS, recentlyOnline, stakingOverview, targets, toggleFavorite }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
-  const { byAuthor, } = useContext(isIntentions ? EmptyAuthorsContext : BlockAuthorsContext);
+  const { byAuthor } = useContext(isIntentions ? EmptyAuthorsContext : BlockAuthorsContext);
   const [nameFilter, setNameFilter] = useState<string>('');
 
   // we have a very large list, so we use a loading delay

--- a/packages/page-staking/src/Validators/CurrentList.tsx
+++ b/packages/page-staking/src/Validators/CurrentList.tsx
@@ -95,7 +95,7 @@ const DEFAULT_PARAS = {};
 function CurrentList ({ className, favorites, hasQueries, isIntentions, isOwn, minCommission, nominatedBy, ownStashIds, paraValidators = DEFAULT_PARAS, recentlyOnline, stakingOverview, targets, toggleFavorite }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
   const { api } = useApi();
-  const { byAuthor, eraPoints } = useContext(isIntentions ? EmptyAuthorsContext : BlockAuthorsContext);
+  const { byAuthor, } = useContext(isIntentions ? EmptyAuthorsContext : BlockAuthorsContext);
   const [nameFilter, setNameFilter] = useState<string>('');
 
   // we have a very large list, so we use a loading delay
@@ -138,7 +138,6 @@ function CurrentList ({ className, favorites, hasQueries, isIntentions, isOwn, m
         [t('other stake'), 'expand'],
         [t('own stake'), 'media--1100'],
         [t('commission')],
-        [t('points')],
         [t('last #')],
         [],
         [undefined, 'media--1200']
@@ -191,7 +190,6 @@ function CurrentList ({ className, favorites, hasQueries, isIntentions, isOwn, m
           lastBlock={byAuthor[address]}
           minCommission={minCommission}
           nominatedBy={nominatedBy?.[address]}
-          points={eraPoints[address]}
           recentlyOnline={recentlyOnline?.[address]}
           toggleFavorite={toggleFavorite}
           validatorInfo={infoMap?.[address]}


### PR DESCRIPTION
Hide `points` column in Staking Overview tab. We don't want it to be displayed as we know compute points every session, not every block. Also at the end of the era, we adjust points with a lenient uptime feature, so we want to display only summary era points in Validator stats tab, which remain untouched in this PR.