### PR TITLE
A0-1101 Make validators APRs equal to each other (with an accuracy up to commission)

### DIFF
--- a/packages/page-staking/src/useSortedTargets.ts
+++ b/packages/page-staking/src/useSortedTargets.ts
@@ -10,7 +10,7 @@ import type { SortedTargets, TargetSortBy, ValidatorInfo } from './types';
 import { useMemo } from 'react';
 
 import { createNamedHook, useAccounts, useApi, useCall, useCallMulti, useInflation } from '@polkadot/react-hooks';
-import { arrayFlatten, BN, BN_HUNDRED, BN_MAX_INTEGER, BN_ONE, BN_ZERO } from '@polkadot/util';
+import { arrayFlatten, BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
 interface LastEra {
   activeEra: BN;
@@ -173,19 +173,15 @@ function extractSingle (api: ApiPromise, allAccounts: string[], derive: DeriveSt
 }
 
 function addReturns (inflation: Inflation, baseInfo: Partial<SortedTargets>): Partial<SortedTargets> {
-  const avgStaked = baseInfo.avgStaked;
   const validators = baseInfo.validators;
 
   if (!validators) {
     return baseInfo;
   }
 
-  avgStaked && !avgStaked.isZero() && validators.forEach((v): void => {
+  validators.forEach((v): void => {
     if (!v.skipRewards && v.withReturns) {
-      const adjusted = avgStaked.mul(BN_HUNDRED).imuln(inflation.stakedReturn).div(v.bondTotal);
-
-      // in some cases, we may have overflows... protect against those
-      v.stakedReturn = (adjusted.gt(BN_MAX_INTEGER) ? BN_MAX_INTEGER : adjusted).toNumber() / BN_HUNDRED.toNumber();
+      v.stakedReturn = inflation.stakedReturn;
       v.stakedReturnCmp = v.stakedReturn * (100 - v.commissionPer) / 100;
     }
   });


### PR DESCRIPTION
Change's Rationale: there's only one place in the code that computes the validator's target APY, in `packages/page-staking/src/useSortedTargets.ts`. That piece uses _global_ `stakedReturns` value that is displayed on top of the `Target` tab in UI. We change the logic so that each validator's staked return just re-uses global value.

Code-wise,  each validator has two fields in its `ValidatorInfo` struct:
```js
export interface ValidatorInfo extends ValidatorInfoRank {
  // ...
  stakedReturn: number;
  stakedReturnCmp: number;
  // ...  
}
```
* `ValidatorInfo::stakedReturn` does not seem to be used, yet it is set to global returns for any not anticipated scenario. Previously, it was a fraction of the average validator stake bond.
*  `ValidatorInfo::stakedReturnCmp` is what actually is displayed in UI in the `Targets` tab in the validator's detail chart. We don't need to modify that field calculation as it was already up to business requirements. 

Testing done:
* on Testnet: note our validators's returns are equal to global return, and external validator have less returns since they have >0 commission,
![image](https://user-images.githubusercontent.com/3909333/180957866-a970b4d7-65eb-4518-b43d-c7f4a08673c5.png)
