### PR TITLE
A0-1187 Decode pallet name and call

### DIFF
--- a/packages/page-storage/src/Selection/Raw.tsx
+++ b/packages/page-storage/src/Selection/Raw.tsx
@@ -62,9 +62,6 @@ function Raw ({ onAdd }: Props): React.ReactElement<Props> {
             return [keyPrefixValue, `${palletName}.${palletCall}`];
           });
       });
-
-      console.log(allStoragePrefixesNotFlattened);
-
       return allStoragePrefixesNotFlattened.flat();
     },
     [api]

--- a/packages/page-storage/src/Selection/Raw.tsx
+++ b/packages/page-storage/src/Selection/Raw.tsx
@@ -62,6 +62,7 @@ function Raw ({ onAdd }: Props): React.ReactElement<Props> {
             return [keyPrefixValue, `${palletName}.${palletCall}`];
           });
       });
+
       return allStoragePrefixesNotFlattened.flat();
     },
     [api]

--- a/packages/page-storage/src/Selection/Raw.tsx
+++ b/packages/page-storage/src/Selection/Raw.tsx
@@ -3,22 +3,31 @@
 
 import type { ComponentProps as Props } from '../types';
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
-import { Button, Input } from '@polkadot/react-components';
+import { Button, Input, Output } from '@polkadot/react-components';
+import { useApi } from '@polkadot/react-hooks';
+import { StorageEntry } from '@polkadot/types/primitive/types';
 import { compactAddLength, u8aToU8a } from '@polkadot/util';
 
 import { useTranslation } from '../translate';
 
 function Raw ({ onAdd }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
-  const [{ isValid, key }, setValue] = useState<{ isValid: boolean; key: Uint8Array }>(() => ({ isValid: false, key: new Uint8Array([]) }));
+  const { api } = useApi();
+  const [{ isValid,
+    key,
+    keyAsBytes }, setValue] = useState<{ isValid: boolean; keyAsBytes: Uint8Array; key: string }>(() => ({
+    isValid: false,
+    key: '',
+    keyAsBytes: new Uint8Array([])
+  }));
 
   const _onAdd = useCallback(
     (): void => {
-      isValid && onAdd({ isConst: false, key });
+      isValid && onAdd({ isConst: false, key: keyAsBytes });
     },
-    [isValid, key, onAdd]
+    [isValid, keyAsBytes, onAdd]
   );
 
   const _onChangeKey = useCallback(
@@ -27,30 +36,96 @@ function Raw ({ onAdd }: Props): React.ReactElement<Props> {
 
       setValue({
         isValid: u8a.length !== 0,
-        key: compactAddLength(u8a)
+        key,
+        keyAsBytes: compactAddLength(u8a)
       });
     },
     []
   );
 
+  const allStoragePrefixes = useMemo(
+    () => {
+      const palletNames = Object
+        .keys(api.query)
+        .map((value): string => (
+          value
+        ));
+      const allStoragePrefixesNotFlattened = palletNames.map((palletName) => {
+        const pallet = api.query[palletName];
+
+        return Object
+          .keys(pallet)
+          .map((palletCall) => {
+            const { keyPrefix } = pallet[palletCall] as unknown as StorageEntry;
+            const keyPrefixValue = keyPrefix().toString();
+
+            return [keyPrefixValue, `${palletName}.${palletCall}`];
+          });
+      });
+
+      console.log(allStoragePrefixesNotFlattened);
+
+      return allStoragePrefixesNotFlattened.flat();
+    },
+    [api]
+  );
+
+  const decodedKey = useMemo(
+    (): string => {
+      if (isValid) {
+        const matchedPrefixes = allStoragePrefixes.filter(([keyPrefix, _]) => {
+          return keyPrefix.includes(key);
+        });
+
+        if (matchedPrefixes.length === 0) {
+          return 'unknown';
+        } else if (matchedPrefixes.length === 1) {
+          return matchedPrefixes[0][1];
+        } else if (matchedPrefixes.length <= 5) {
+          return `Found ${matchedPrefixes.length} matches: ` +
+            matchedPrefixes
+              .map(([_, [palletName, palletCall]]) => `${palletName}.${palletCall}`)
+              .join(', ');
+        } else {
+          return `Found ${matchedPrefixes.length} matches`;
+        }
+      }
+
+      return 'unknown';
+    },
+    [isValid, key, allStoragePrefixes]
+  );
+
   return (
-    <section className='storage--actionrow'>
-      <div className='storage--actionrow-value'>
-        <Input
-          autoFocus
-          label={t<string>('hex-encoded storage key')}
-          onChange={_onChangeKey}
-          onEnter={_onAdd}
-        />
-      </div>
-      <div className='storage--actionrow-buttons'>
-        <Button
-          icon='plus'
-          isDisabled={!isValid}
-          onClick={_onAdd}
-        />
-      </div>
-    </section>
+    <>
+      <section className='storage--actionrow'>
+        <div className='storage--actionrow-value'>
+          <Input
+            autoFocus
+            label={t<string>('hex-encoded storage key')}
+            onChange={_onChangeKey}
+            onEnter={_onAdd}
+          />
+        </div>
+        <div className='storage--actionrow-buttons'>
+          <Button
+            icon='plus'
+            isDisabled={!isValid}
+            onClick={_onAdd}
+          />
+        </div>
+      </section>
+      <section>
+        <div className='storage--actionrow-decoded'>
+          <Output
+            isDisabled
+            label={t<string>('Decoded pallet name and call')}
+            value={decodedKey}
+            withCopy
+          />
+        </div>
+      </section>
+    </>
   );
 }
 

--- a/packages/page-storage/src/Selection/Raw.tsx
+++ b/packages/page-storage/src/Selection/Raw.tsx
@@ -84,7 +84,7 @@ function Raw ({ onAdd }: Props): React.ReactElement<Props> {
         } else if (matchedPrefixes.length <= 5) {
           return `Found ${matchedPrefixes.length} matches: ` +
             matchedPrefixes
-              .map(([_, [palletName, palletCall]]) => `${palletName}.${palletCall}`)
+              .map((value) => value[1])
               .join(', ');
         } else {
           return `Found ${matchedPrefixes.length} matches`;


### PR DESCRIPTION
This is 1/3 part of the new feature to add display decoded raw storage entries in UI. All parts will be merged first into an interim `A0-1086-decoding-raw-chainspec` branch as per our wallet deployment model, followed by final PR to branch `aleph-zero`.

When a raw key is put in the `hex-encoded storage key` field, logic takes a substring of the potential pallet.call encoded `StorageKey`:
* if nothing was found, it displays `unknown`, 
* if exactly one match was found, it displays that match:
![image](https://user-images.githubusercontent.com/3909333/181737315-f38c2d7c-f7b1-473e-b2a3-8cdd26a47f84.png)

* if more than one match but less or equal than 5 were found, then it says how many matches and concatenates all possible matches:
![image](https://user-images.githubusercontent.com/3909333/181737669-6e1088e1-46cb-41d0-a515-08d1122877fa.png)
* if more than 5 matches were found, it displays only information about that count 
![image](https://user-images.githubusercontent.com/3909333/181737868-838fd863-77a3-446b-8ff0-904108a35e8c.png)
