### PR TITLE
A0 1131 support for past queries

### DIFF
--- a/packages/page-staking/src/Performance/Address/index.tsx
+++ b/packages/page-staking/src/Performance/Address/index.tsx
@@ -18,7 +18,7 @@ interface Props {
   toggleFavorite: (accountId: string) => void;
   blocksCreated: number,
   blocksTarget: number,
-  rewardPercentage: number,
+  rewardPercentage: string,
 }
 
 function useAddressCalls (api: ApiPromise, address: string) {

--- a/packages/page-staking/src/Performance/CurrentList.tsx
+++ b/packages/page-staking/src/Performance/CurrentList.tsx
@@ -66,11 +66,10 @@ function CurrentList ({ className, toggleFavorite, validatorPerformances }: Prop
 
     if (blocksTargetValue > 0) {
       rewardPercentage = 100 * blocksCreated / blocksTargetValue;
+      if (rewardPercentage >= 90) {
+        rewardPercentage = 100;
+      }
     } else if (blocksTargetValue === 0 && blocksCreated === 0) {
-      rewardPercentage = 100;
-    }
-
-    if (rewardPercentage >= 90) {
       rewardPercentage = 100;
     }
 

--- a/packages/page-staking/src/Performance/CurrentList.tsx
+++ b/packages/page-staking/src/Performance/CurrentList.tsx
@@ -69,7 +69,7 @@ function mapValidators (infos: ValidatorInfo[]): Record<string, ValidatorInfo> {
 function CurrentList ({ className, currentSessionCommittee, eraValidators, expectedSessionValidatorBlockCount, favorites, sessionValidatorBlockCountLookup, targets, toggleFavorite }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const [nameFilter, setNameFilter] = useState<string>('');
-  const [allEraValidators, setAllEraValidators] = useState(true);
+  const [allEraValidators, setAllEraValidators] = useState(false);
 
   const isLoading = useLoadingDelay();
 

--- a/packages/page-staking/src/Performance/CurrentList.tsx
+++ b/packages/page-staking/src/Performance/CurrentList.tsx
@@ -66,6 +66,7 @@ function CurrentList ({ className, toggleFavorite, validatorPerformances }: Prop
 
     if (blocksTargetValue > 0) {
       rewardPercentage = 100 * blocksCreated / blocksTargetValue;
+
       if (rewardPercentage >= 90) {
         rewardPercentage = 100;
       }

--- a/packages/page-staking/src/Performance/Performance.tsx
+++ b/packages/page-staking/src/Performance/Performance.tsx
@@ -71,7 +71,7 @@ function Performance ({ className = '', favorites, sessionEra, toggleFavorite }:
   );
 
   useEffect(() => {
-    if (firstBlockInSessionHash !== undefined) {
+    if (firstBlockInSessionHash) {
       api.at(firstBlockInSessionHash.toString()).then((result) => {
         result.query.elections.palletVersion().then((version) => {
           setIsPalletElectionsSupported(Number(version.toString()) >= MINIMUM_SUPPORTED_ELECTIONS_PALLET_VERSION);
@@ -97,7 +97,7 @@ function Performance ({ className = '', favorites, sessionEra, toggleFavorite }:
   );
 
   useEffect(() => {
-    if (firstBlockInSessionHash !== undefined) {
+    if (firstBlockInSessionHash) {
       api.derive.chain.getHeader(firstBlockInSessionHash).then((header) => {
         if (header && !header.isEmpty && header.author) {
           setFirstSessionBlockAuthor(header.author.toString());
@@ -124,7 +124,7 @@ function Performance ({ className = '', favorites, sessionEra, toggleFavorite }:
   }
 
   useEffect(() => {
-    if (lastBlockInSessionHash !== undefined && firstSessionBlockAuthor !== undefined) {
+    if (lastBlockInSessionHash && firstSessionBlockAuthor) {
       api.at(lastBlockInSessionHash.toString()).then((result) => {
         const sessionValidatorBlockCount = result.query.elections.sessionValidatorBlockCount;
 
@@ -152,7 +152,7 @@ function Performance ({ className = '', favorites, sessionEra, toggleFavorite }:
   }, [firstSessionBlockAuthor, sessionEra, api]);
 
   useEffect(() => {
-    if (firstBlockInSessionHash !== undefined) {
+    if (firstBlockInSessionHash) {
       api.at(firstBlockInSessionHash.toString()).then((resultApi) => {
         const validators = resultApi.query.session.validators;
 
@@ -194,8 +194,8 @@ function Performance ({ className = '', favorites, sessionEra, toggleFavorite }:
       const count = maybeCount ? maybeCount[1] : 0;
       const maybeExpectedBlockCount = expectedSessionValidatorBlockCount.find(([id]) => id === validator);
       const expectedBlockCount = maybeExpectedBlockCount ? maybeExpectedBlockCount[1] : 0;
-      const isCommittee = committee.find((value) => validator === value) !== undefined;
-      const isFavourite = favorites.find((value) => validator === value) !== undefined;
+      const isCommittee = !!committee.find((value) => validator === value);
+      const isFavourite = !!favorites.find((value) => validator === value);
 
       return {
         accountId: validator,
@@ -215,12 +215,12 @@ function Performance ({ className = '', favorites, sessionEra, toggleFavorite }:
   return (
     <div className={`staking--Performance ${className}`}>
       {isPalletElectionsSupported === undefined && <Spinner label={'Checking storage version'} />}
-      {isPalletElectionsSupported !== undefined && !isPalletElectionsSupported &&
+      {!isPalletElectionsSupported !== undefined && !isPalletElectionsSupported &&
          <MarkWarning
            className='warning centered'
            content={<>Unsupported pallet elections storage version. Choose more recent session number.</>}
          />}
-      {isPalletElectionsSupported !== undefined && isPalletElectionsSupported &&
+      {isPalletElectionsSupported &&
          (<>
            <Summary
              committee={committee}

--- a/packages/page-staking/src/Performance/Performance.tsx
+++ b/packages/page-staking/src/Performance/Performance.tsx
@@ -1,17 +1,14 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SortedTargets } from '../types';
+import React, { useEffect, useMemo, useState } from 'react';
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
-
-import { ApiDecoration } from '@polkadot/api/types';
-import { MarkWarning } from '@polkadot/react-components';
+import { DeriveEraExposure } from '@polkadot/api-derive/types';
+import { MarkWarning, Spinner } from '@polkadot/react-components';
 import { useApi, useCall } from '@polkadot/react-hooks';
-import { StorageKey, Vec } from '@polkadot/types';
-import { AccountId, EraIndex, Hash } from '@polkadot/types/interfaces';
+import { StorageKey } from '@polkadot/types';
+import { Hash } from '@polkadot/types/interfaces';
 import { AnyTuple, Codec } from '@polkadot/types/types';
-import { Option, Struct, u32 } from '@polkadot/types-codec';
 
 import ActionsBanner from './ActionsBanner';
 import CurrentList from './CurrentList';
@@ -21,136 +18,86 @@ import Summary from './Summary';
 interface Props {
   className?: string;
   favorites: string[];
-  targets: SortedTargets;
   toggleFavorite: (address: string) => void;
   sessionEra: SessionEra,
-  currentSessionMode: boolean,
 }
 
-interface CurrentEraValidators extends Struct {
-  reserved: Vec<AccountId>;
-  nonReserved: Vec<AccountId>;
+export interface ValidatorPerformance {
+  accountId: string,
+  blockCount: number,
+  expectedBlockCount: number,
+  isCommittee: boolean;
+  isFavourite: boolean,
 }
 
-interface CommitteeSize extends Struct {
-  nonReservedSeats: u32
-  reservedSeats: u32,
-}
-
-type SessionIndexEntry = [{ args: [EraIndex] }, Option<u32>];
-
-function Performance ({ className = '', currentSessionMode, favorites, sessionEra, targets, toggleFavorite }: Props): React.ReactElement<Props> {
+function Performance ({ className = '', favorites, sessionEra, toggleFavorite }: Props): React.ReactElement<Props> {
   const { api } = useApi();
 
-  const erasStartSessionIndex = useCall<SessionIndexEntry[]>(api.query.staking.erasStartSessionIndex.entries);
-  const [firstBlockInSessionHash, setFirstBlockInSessionHash] = useState<Hash | null>(null);
-  const [lastBlockInSessionHash, setLastBlockInSessionHash] = useState<Hash | null>(null);
-  const [currentEraValidators, setCurrentEraValidators] = useState<CurrentEraValidators | null>(null);
-  const [committeeSize, setCommitteeSize] = useState<CommitteeSize | null>(null);
-  const [sessionValidatorBlockCountLookup, setSessionValidatorBlockCountLookup] = useState<Record<string, number>>({});
-  const [firstSessionBlockAuthor, setFirstSessionBlockAuthor] = useState<string>('');
-  const [isPalletElectionsSupported, setIsPalletElectionsSupported] = useState<boolean>(false);
+  const [validatorPerformances, setValidatorPerformances] = useState<ValidatorPerformance[]>([]);
+  const [committee, setCommittee] = useState<string[]>([]);
+
+  const [firstBlockInSessionHash, setFirstBlockInSessionHash] = useState<Hash | undefined>(undefined);
+  const [lastBlockInSessionHash, setLastBlockInSessionHash] = useState<Hash | undefined>(undefined);
+  const [firstSessionBlockAuthor, setFirstSessionBlockAuthor] = useState<string | undefined>(undefined);
+  const [isPalletElectionsSupported, setIsPalletElectionsSupported] = useState<boolean | undefined>(undefined);
+
+  const [sessionValidatorBlockCountLookup, setSessionValidatorBlockCountLookup] = useState<[string, number][]>([]);
 
   const MINIMUM_SUPPORTED_ELECTIONS_PALLET_VERSION = 3;
 
-  const era: number | null = useMemo(() => {
-    if (currentSessionMode) {
-      if (!sessionEra.era) {
-        console.warn('sessionEra.era should not be undefined in the current session mode!');
+  const eraExposure = useCall<DeriveEraExposure>(api.derive.staking.eraExposure, [sessionEra.era]);
 
-        return null;
-      }
-
-      return sessionEra.era;
+  const eraValidators = useMemo(() => {
+    if (eraExposure?.validators) {
+      return Object.keys(eraExposure?.validators);
     }
 
-    if (!erasStartSessionIndex) {
-      return null;
-    }
-
-    const erasStartSessionIndexLookup: [number, number][] = [];
-
-    erasStartSessionIndex.filter(([, values]) => values.isSome)
-      .forEach(([key, values]) => {
-        const eraIndex = key.args[0];
-
-        erasStartSessionIndexLookup.push([eraIndex.toNumber(), values.unwrap().toNumber()]);
-      });
-    erasStartSessionIndexLookup.sort(([eraIndexA], [eraIndexB]) => {
-      return eraIndexA - eraIndexB;
-    });
-
-    for (let i = 0; i < erasStartSessionIndexLookup.length; i++) {
-      const eraIndex = erasStartSessionIndexLookup[i][0];
-      const currentEraSessionStart = erasStartSessionIndexLookup[i][1];
-      const currentEraSessionEnd = i + 1 < erasStartSessionIndexLookup.length ? erasStartSessionIndexLookup[i + 1][1] - 1 : null;
-
-      if (currentEraSessionStart <= sessionEra.session && currentEraSessionEnd && sessionEra.session <= currentEraSessionEnd) {
-        return eraIndex;
-      }
-    }
-
-    const lastErasStartSessionIndexLookup = erasStartSessionIndexLookup.length - 1;
-
-    return erasStartSessionIndexLookup[lastErasStartSessionIndexLookup][0];
-  },
-  [erasStartSessionIndex, sessionEra, currentSessionMode]
+    return [];
+  }, [eraExposure]
   );
 
   useEffect(() => {
-    if (era) {
+    const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
+    const firstBlockInSession = sessionEra.session * sessionPeriod;
+
+    api.rpc.chain
+      .getBlockHash(firstBlockInSession)
+      .then((result): void => {
+        setFirstBlockInSessionHash(result);
+      })
+      .catch(console.error);
+  },
+  [api, sessionEra]
+  );
+
+  useEffect(() => {
+    if (firstBlockInSessionHash !== undefined) {
+      api.at(firstBlockInSessionHash.toString()).then((result) => {
+        result.query.elections.palletVersion().then((version) => {
+          setIsPalletElectionsSupported(Number(version.toString()) >= MINIMUM_SUPPORTED_ELECTIONS_PALLET_VERSION);
+        }).catch(console.error);
+      }).catch(console.error);
+    }
+  }, [api, firstBlockInSessionHash]);
+
+  useEffect(() => {
+    if (!sessionEra.currentSessionMode) {
       const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
-      const firstBlockInSession = sessionEra.session * sessionPeriod;
+      const lastBlockInSession = (sessionEra.session + 1) * sessionPeriod - 1;
 
       api.rpc.chain
-        .getBlockHash(firstBlockInSession)
+        .getBlockHash(lastBlockInSession)
         .then((result): void => {
-          setFirstBlockInSessionHash(result);
+          setLastBlockInSessionHash(result);
         })
         .catch(console.error);
-
-      if (!currentSessionMode) {
-        const lastBlockInSession = (sessionEra.session + 1) * sessionPeriod - 1;
-
-        api.rpc.chain
-          .getBlockHash(lastBlockInSession)
-          .then((result): void => {
-            setLastBlockInSessionHash(result);
-          })
-          .catch(console.error);
-      }
     }
   },
-  [api, era, sessionEra.session, currentSessionMode]
+  [api, sessionEra]
   );
 
-  function getSessionValidators (currentApi: ApiDecoration<'promise'>) {
-    currentApi.query.elections.palletVersion().then((version) => {
-      if (Number(version.toString()) >= MINIMUM_SUPPORTED_ELECTIONS_PALLET_VERSION) {
-        setIsPalletElectionsSupported(true);
-        currentApi.query.elections.currentEraValidators().then((currentEraValidatorsValue) => {
-          if (currentEraValidatorsValue) {
-            setCurrentEraValidators(currentEraValidatorsValue as CurrentEraValidators);
-          }
-        }).catch(console.error);
-        currentApi.query.elections.committeeSize().then((committeeSizeValue) => {
-          if (committeeSizeValue) {
-            setCommitteeSize(committeeSizeValue as CommitteeSize);
-          }
-        }).catch(console.error);
-      } else {
-        setIsPalletElectionsSupported(false);
-      }
-    }).catch(console.error);
-  }
-
   useEffect(() => {
-    if (firstBlockInSessionHash) {
-      api.at(firstBlockInSessionHash.toString()).then((result) => {
-        if (result) {
-          getSessionValidators(result);
-        }
-      }).catch(console.error);
+    if (firstBlockInSessionHash !== undefined) {
       api.derive.chain.getHeader(firstBlockInSessionHash).then((header) => {
         if (header && !header.isEmpty && header.author) {
           setFirstSessionBlockAuthor(header.author.toString());
@@ -161,159 +108,133 @@ function Performance ({ className = '', currentSessionMode, favorites, sessionEr
   [api, firstBlockInSessionHash]
   );
 
-  const parseSessionValidatorBlockCount = useCallback((sessionValidatorBlockCountValue: [StorageKey<AnyTuple>, Codec][]) => {
-    const sessionValidatorBlockCountLookup: Record<string, number> = {};
-
-    sessionValidatorBlockCountValue.forEach(([key, values]) => {
+  function parseSessionBlockCount (sessionValidatorBlockCountValue: [StorageKey<AnyTuple>, Codec][], firstSessionBlockAuthor: string): [string, number][] {
+    return sessionValidatorBlockCountValue.map(([key, values]) => {
       const account = key.args[0].toString();
-
-      sessionValidatorBlockCountLookup[account] = Number(values.toString());
+      let count = Number(values.toString());
 
       if (account === firstSessionBlockAuthor) {
         // a workaround for the fact that the first session block author is not reflected in that block
         // elections.sessionValidatorBlockCount state
-        sessionValidatorBlockCountLookup[account] += 1;
+        count += 1;
       }
-    });
-    setSessionValidatorBlockCountLookup(sessionValidatorBlockCountLookup);
-  }, [firstSessionBlockAuthor]
-  );
 
-  const setBlockCountLookup = useCallback((currentApi: ApiDecoration<'promise'>) => {
-    currentApi.query.elections.palletVersion().then((version) => {
-      if (Number(version.toString()) >= MINIMUM_SUPPORTED_ELECTIONS_PALLET_VERSION) {
-        currentApi.query.elections.sessionValidatorBlockCount.entries().then((sessionValidatorBlockCountValue) => {
-          if (sessionValidatorBlockCountValue) {
-            parseSessionValidatorBlockCount(sessionValidatorBlockCountValue);
-          }
+      return [account, count];
+    });
+  }
+
+  useEffect(() => {
+    if (lastBlockInSessionHash !== undefined && firstSessionBlockAuthor !== undefined) {
+      api.at(lastBlockInSessionHash.toString()).then((result) => {
+        const sessionValidatorBlockCount = result.query.elections.sessionValidatorBlockCount;
+
+        sessionValidatorBlockCount && sessionValidatorBlockCount.entries().then((value) => {
+          setSessionValidatorBlockCountLookup(parseSessionBlockCount(value, firstSessionBlockAuthor));
         }).catch(console.error);
-      } else {
-        setIsPalletElectionsSupported(false);
-      }
-    }).catch(console.error);
-  }, [parseSessionValidatorBlockCount]
+      }).catch(console.error);
+    }
+  }
+  , [api, lastBlockInSessionHash, firstSessionBlockAuthor]
   );
 
   useEffect(() => {
-    if (lastBlockInSessionHash && isPalletElectionsSupported) {
-      api.at(lastBlockInSessionHash.toString()).then((result) => {
-        if (result) {
-          setBlockCountLookup(result);
+    const interval = setInterval(() => {
+      if (sessionEra.currentSessionMode && firstSessionBlockAuthor) {
+        api && api.query.elections && api.query.elections.sessionValidatorBlockCount &&
+        api.query.elections.sessionValidatorBlockCount.entries().then((value) => {
+          setSessionValidatorBlockCountLookup(parseSessionBlockCount(value, firstSessionBlockAuthor));
         }
+        ).catch(console.error);
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [firstSessionBlockAuthor, sessionEra, api]);
+
+  useEffect(() => {
+    if (firstBlockInSessionHash !== undefined) {
+      api.at(firstBlockInSessionHash.toString()).then((resultApi) => {
+        const validators = resultApi.query.session.validators;
+
+        validators && validators().then((value) => {
+          setCommittee(value.map((validator) => validator.toString()));
+        }).catch(console.error);
       }).catch(console.error);
     }
-  },
-  [api, lastBlockInSessionHash, isPalletElectionsSupported, setBlockCountLookup]
-  );
-
-  function chooseForSession (validators: AccountId[], count: number, sessionIndex: number) {
-    const validatorsLength = validators.length;
-    const firstIndex = sessionIndex * count % validatorsLength;
-    const chosen: Array<AccountId> = [];
-
-    for (let i = 0; i < Math.min(count, validatorsLength); i++) {
-      chosen.push(validators[(firstIndex + i) % validatorsLength]);
-    }
-
-    return chosen;
-  }
-
-  const [eraValidators, currentSessionCommittee] = useMemo(
-    () => {
-      if (!currentEraValidators || !committeeSize || !isPalletElectionsSupported) {
-        return [null, null];
-      }
-
-      const nonReserved = currentEraValidators.nonReserved.toArray();
-      const reserved = currentEraValidators.reserved.toArray();
-      const nonReservedFreeSeats = committeeSize.nonReservedSeats.toNumber();
-      const reservedFreeSeats = committeeSize.reservedSeats.toNumber();
-      const currentSession = sessionEra.session;
-
-      const chosenFromNonReserved = chooseForSession(nonReserved, nonReservedFreeSeats, currentSession);
-      const chosenFromReserved = chooseForSession(reserved, reservedFreeSeats, currentSession);
-
-      const currentSessionCommittee = chosenFromReserved.concat(chosenFromNonReserved);
-      const eraValidators = reserved.concat(nonReserved);
-
-      return [eraValidators, currentSessionCommittee];
-    },
-    [currentEraValidators, committeeSize, sessionEra, isPalletElectionsSupported]
+  }, [api, firstBlockInSessionHash]
   );
 
   const expectedSessionValidatorBlockCount = useMemo(() => {
-    if (!firstSessionBlockAuthor || !eraValidators || !currentSessionCommittee || !isPalletElectionsSupported) {
-      return {};
-    }
-
-    const resultLookup: Record<string, number> = {};
+    const result: [string, number][] = [];
 
     // should not change at all during runtime, therefore it's fine to use current api object
     const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
 
-    const index = currentSessionCommittee.findIndex((value) => value.toString() === firstSessionBlockAuthor);
+    const index = committee.findIndex((value) => value.toString() === firstSessionBlockAuthor);
 
     if (index === -1) {
-      console.warn('Sth went wrong, could not find first block session author!');
-
-      return {};
+      return [];
     }
 
-    for (let i = 0; i < currentSessionCommittee.length; i++) {
-      const author = currentSessionCommittee[(i + index) % currentSessionCommittee.length];
+    for (let i = 0; i < committee.length; i++) {
+      const author = committee[(i + index) % committee.length];
       const offset = Math.max(sessionPeriod - i, 0);
 
-      resultLookup[author.toString()] = Math.ceil(offset / currentSessionCommittee.length);
+      result.push([author.toString(), Math.ceil(offset / committee.length)]);
     }
 
-    return resultLookup;
+    return result;
   },
-  [api, firstSessionBlockAuthor, eraValidators, currentSessionCommittee, isPalletElectionsSupported]
+  [api, firstSessionBlockAuthor, committee]
   );
 
-  // this is not very optimal is it is run every render
-  // it is a workaround for api.query.elections.sessionValidatorBlockCount.entries not working as expected with useCall
   useEffect(() => {
-    if (currentSessionMode) {
-      api && api.query.elections && api.query.elections.sessionValidatorBlockCount &&
-        api.query.elections.sessionValidatorBlockCount.entries().then(
-          (result) => {
-            if (result) {
-              parseSessionValidatorBlockCount(result);
-            }
-          }
-        ).catch(console.error);
-    }
-  }
+    const performances = eraValidators.map((validator) => {
+      const maybeCount = sessionValidatorBlockCountLookup.find(([id]) => id === validator);
+      const count = maybeCount ? maybeCount[1] : 0;
+      const maybeExpectedBlockCount = expectedSessionValidatorBlockCount.find(([id]) => id === validator);
+      const expectedBlockCount = maybeExpectedBlockCount ? maybeExpectedBlockCount[1] : 0;
+      const isCommittee = committee.find((value) => validator === value) !== undefined;
+      const isFavourite = favorites.find((value) => validator === value) !== undefined;
+
+      return {
+        accountId: validator,
+        blockCount: count,
+        expectedBlockCount,
+        isCommittee,
+        isFavourite
+      };
+    });
+
+    setValidatorPerformances(performances);
+  },
+  [committee, eraValidators, sessionValidatorBlockCountLookup, expectedSessionValidatorBlockCount, favorites]
+
   );
 
   return (
     <div className={`staking--Performance ${className}`}>
-      {!isPalletElectionsSupported
-        ? <MarkWarning
-          className='warning centered'
-          content={<>Unsupported pallet elections storage version. Choose more recent session number.</>}
-        />
-        : (<>
-          <Summary
-            currentSessionCommittee={currentSessionCommittee || []}
-            era={era}
-            eraValidators={eraValidators || []}
-            session={sessionEra.session}
-            targets={targets}
-          />
-          <ActionsBanner />
-          <CurrentList
-            currentSessionCommittee={currentSessionCommittee || []}
-            eraValidators={eraValidators || []}
-            expectedSessionValidatorBlockCount={expectedSessionValidatorBlockCount}
-            favorites={favorites}
-            session={sessionEra.session}
-            sessionValidatorBlockCountLookup={sessionValidatorBlockCountLookup}
-            targets={targets}
-            toggleFavorite={toggleFavorite}
-          />
-        </>)}
+      {isPalletElectionsSupported === undefined && <Spinner label={'Checking storage version'} />}
+      {isPalletElectionsSupported !== undefined && !isPalletElectionsSupported &&
+         <MarkWarning
+           className='warning centered'
+           content={<>Unsupported pallet elections storage version. Choose more recent session number.</>}
+         />}
+      {isPalletElectionsSupported !== undefined && isPalletElectionsSupported &&
+         (<>
+           <Summary
+             committee={committee}
+             era={sessionEra.era}
+             session={sessionEra.session}
+             validatorPerformances={validatorPerformances}
+           />
+           <ActionsBanner />
+           <CurrentList
+             session={sessionEra.session}
+             toggleFavorite={toggleFavorite}
+             validatorPerformances={validatorPerformances}
+           />
+         </>)}
     </div>
   );
 }

--- a/packages/page-staking/src/Performance/Summary.tsx
+++ b/packages/page-staking/src/Performance/Summary.tsx
@@ -6,21 +6,23 @@ import type { SortedTargets } from '../types';
 import React from 'react';
 import styled from 'styled-components';
 
-import SummarySession from '@polkadot/app-explorer/SummarySession';
 import { CardSummary, Spinner, SummaryBox } from '@polkadot/react-components';
 import { AccountId } from '@polkadot/types/interfaces';
 import { formatNumber } from '@polkadot/util';
 
 import { useTranslation } from '../translate';
+import SummarySession from "@polkadot/app-staking/Performance/SummarySession";
 
 interface Props {
   className?: string;
   eraValidators: AccountId[];
   currentSessionCommittee: AccountId[];
   targets: SortedTargets;
+  era: number;
+  session: number;
 }
 
-function Summary ({ className = '', currentSessionCommittee, eraValidators }: Props): React.ReactElement<Props> {
+function Summary ({ className = '', currentSessionCommittee, eraValidators, era, session }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
 
   return (
@@ -40,7 +42,10 @@ function Summary ({ className = '', currentSessionCommittee, eraValidators }: Pr
         </CardSummary>
       </section>
       <section>
-        <SummarySession />
+        <SummarySession
+            era={era}
+            session={session}
+        />
       </section>
     </SummaryBox>
   );

--- a/packages/page-staking/src/Performance/Summary.tsx
+++ b/packages/page-staking/src/Performance/Summary.tsx
@@ -1,42 +1,40 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SortedTargets } from '../types';
-
 import React from 'react';
 import styled from 'styled-components';
 
 import SummarySession from '@polkadot/app-staking/Performance/SummarySession';
 import { CardSummary, Spinner, SummaryBox } from '@polkadot/react-components';
-import { AccountId } from '@polkadot/types/interfaces';
 import { formatNumber } from '@polkadot/util';
 
 import { useTranslation } from '../translate';
+import { ValidatorPerformance } from './Performance';
 
 interface Props {
   className?: string;
-  eraValidators: AccountId[];
-  currentSessionCommittee: AccountId[];
-  targets: SortedTargets;
+  validatorPerformances: ValidatorPerformance[];
   era: number;
   session: number;
 }
 
-function Summary ({ className = '', currentSessionCommittee, era, eraValidators, session }: Props): React.ReactElement<Props> {
+function Summary ({ className = '', era, session, validatorPerformances }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
+
+  const committeeLength = validatorPerformances.filter((performance) => performance.isCommittee).length;
 
   return (
     <SummaryBox className={className}>
       <section>
         <CardSummary label={t<string>('era validators')}>
-          {eraValidators.length > 0
-            ? <>{formatNumber(eraValidators.length)}</>
+          {validatorPerformances.length > 0
+            ? <>{formatNumber(validatorPerformances.length)}</>
             : <Spinner noLabel />
           }
         </CardSummary>
         <CardSummary label={t<string>('committee size')}>
-          {currentSessionCommittee.length > 0
-            ? <>{formatNumber(currentSessionCommittee.length)}</>
+          {committeeLength > 0
+            ? <>{formatNumber(committeeLength)}</>
             : <Spinner noLabel />
           }
         </CardSummary>

--- a/packages/page-staking/src/Performance/Summary.tsx
+++ b/packages/page-staking/src/Performance/Summary.tsx
@@ -27,7 +27,7 @@ function Summary ({ className = '', era, session, validatorPerformances }: Props
     <SummaryBox className={className}>
       <section>
         <CardSummary label={t<string>('era validators')}>
-          {validatorPerformances.length > 0
+          {validatorPerformances.length
             ? <>{formatNumber(validatorPerformances.length)}</>
             : <Spinner noLabel />
           }

--- a/packages/page-staking/src/Performance/Summary.tsx
+++ b/packages/page-staking/src/Performance/Summary.tsx
@@ -6,12 +6,12 @@ import type { SortedTargets } from '../types';
 import React from 'react';
 import styled from 'styled-components';
 
+import SummarySession from '@polkadot/app-staking/Performance/SummarySession';
 import { CardSummary, Spinner, SummaryBox } from '@polkadot/react-components';
 import { AccountId } from '@polkadot/types/interfaces';
 import { formatNumber } from '@polkadot/util';
 
 import { useTranslation } from '../translate';
-import SummarySession from "@polkadot/app-staking/Performance/SummarySession";
 
 interface Props {
   className?: string;
@@ -22,7 +22,7 @@ interface Props {
   session: number;
 }
 
-function Summary ({ className = '', currentSessionCommittee, eraValidators, era, session }: Props): React.ReactElement<Props> {
+function Summary ({ className = '', currentSessionCommittee, era, eraValidators, session }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
 
   return (
@@ -43,8 +43,8 @@ function Summary ({ className = '', currentSessionCommittee, eraValidators, era,
       </section>
       <section>
         <SummarySession
-            era={era}
-            session={session}
+          era={era}
+          session={session}
         />
       </section>
     </SummaryBox>

--- a/packages/page-staking/src/Performance/SummarySession.tsx
+++ b/packages/page-staking/src/Performance/SummarySession.tsx
@@ -1,0 +1,36 @@
+// Copyright 2017-2022 @polkadot/app-explorer authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+import { CardSummary } from '@polkadot/react-components';
+import { formatNumber } from '@polkadot/util';
+import { useTranslation } from "@polkadot/app-explorer/translate";
+
+interface Props {
+  className?: string;
+  session: number;
+  era: number;
+}
+
+function SummarySession ({ className, session, era }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+
+  return (
+        <>
+                <CardSummary label={t<string>('session')}>
+                  #{formatNumber(session)}
+                </CardSummary>
+
+                <CardSummary
+                  className={className}
+                  label={t<string>('era')}
+                >
+                  #{formatNumber(era)}
+                </CardSummary>
+
+        </>
+  );
+}
+
+export default React.memo(SummarySession);

--- a/packages/page-staking/src/Performance/SummarySession.tsx
+++ b/packages/page-staking/src/Performance/SummarySession.tsx
@@ -3,9 +3,9 @@
 
 import React from 'react';
 
+import { useTranslation } from '@polkadot/app-explorer/translate';
 import { CardSummary } from '@polkadot/react-components';
 import { formatNumber } from '@polkadot/util';
-import { useTranslation } from "@polkadot/app-explorer/translate";
 
 interface Props {
   className?: string;
@@ -13,23 +13,22 @@ interface Props {
   era: number;
 }
 
-function SummarySession ({ className, session, era }: Props): React.ReactElement<Props> {
+function SummarySession ({ className, era, session }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
 
   return (
-        <>
-                <CardSummary label={t<string>('session')}>
+    <>
+      <CardSummary label={t<string>('session')}>
                   #{formatNumber(session)}
-                </CardSummary>
-
-                <CardSummary
-                  className={className}
-                  label={t<string>('era')}
-                >
+      </CardSummary>
+      <CardSummary
+        className={className}
+        label={t<string>('era')}
+      >
                   #{formatNumber(era)}
-                </CardSummary>
+      </CardSummary>
 
-        </>
+    </>
   );
 }
 

--- a/packages/page-staking/src/Performance/index.tsx
+++ b/packages/page-staking/src/Performance/index.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 
 import { DeriveSessionProgress } from '@polkadot/api-derive/types';
 import { useTranslation } from '@polkadot/app-staking/translate';
-import { Input, Spinner } from '@polkadot/react-components';
+import { Input, MarkWarning, Spinner } from '@polkadot/react-components';
 import { useApi, useCall } from '@polkadot/react-hooks';
 import { EraIndex } from '@polkadot/types/interfaces';
 import { Option, u32 } from '@polkadot/types-codec';
@@ -31,7 +31,7 @@ function PerformancePage ({ favorites, toggleFavorite }: Props): React.ReactElem
   const { api } = useApi();
   const sessionInfo = useCall<DeriveSessionProgress>(api.derive.session.progress);
   const historyDepth = useCall<number>(api.query.staking.historyDepth);
-  const [ parsedSessionNumber, setParsedSessionNumber ] = useState<number | undefined>(undefined);
+  const [parsedSessionNumber, setParsedSessionNumber] = useState<number | undefined>(undefined);
   const [inputSession, setInputSession] = useState<number | null>(null);
   const erasStartSessionIndex = useCall<SessionIndexEntry[]>(api.query.staking.erasStartSessionIndex.entries);
 
@@ -60,6 +60,7 @@ function PerformancePage ({ favorites, toggleFavorite }: Props): React.ReactElem
   const _onChangeKey = useCallback(
     (key: string): void => {
       let isInputSessionNumberCorrect = false;
+
       if (currentSession && historyDepth && minimumSessionNumber) {
         const sessionNumber = parseInt(key);
 
@@ -69,9 +70,10 @@ function PerformancePage ({ favorites, toggleFavorite }: Props): React.ReactElem
           }
         }
       }
-      isInputSessionNumberCorrect ?
-        setParsedSessionNumber(Number(key)) :
-        setParsedSessionNumber(undefined);
+
+      isInputSessionNumberCorrect
+        ? setParsedSessionNumber(Number(key))
+        : setParsedSessionNumber(undefined);
     },
     [currentSession, minimumSessionNumber, historyDepth]
   );
@@ -138,8 +140,14 @@ function PerformancePage ({ favorites, toggleFavorite }: Props): React.ReactElem
       }
     }
 
-    return;
+    return undefined;
   }, [inputSession, currentEra, currentSession, erasStartSessionIndex]);
+
+  if (!api.runtimeChain.toString().includes('Aleph Zero')) {
+    return (
+      <MarkWarning content={'Unsupported chain.'} />
+    );
+  }
 
   return (
     <div>

--- a/packages/page-staking/src/Performance/index.tsx
+++ b/packages/page-staking/src/Performance/index.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { DeriveSessionProgress } from '@polkadot/api-derive/types';
 import { useTranslation } from '@polkadot/app-staking/translate';
 import { SortedTargets } from '@polkadot/app-staking/types';
-import {Input, Spinner} from '@polkadot/react-components';
+import { Input, Spinner } from '@polkadot/react-components';
 import { useApi, useCall } from '@polkadot/react-hooks';
 
 import Performance from './Performance';
@@ -41,9 +41,9 @@ function PerformancePage ({ favorites, targets, toggleFavorite }: Props): React.
   );
 
   const currentEra = useMemo(() => {
-      return sessionInfo?.currentEra.toNumber();
-    },
-    [sessionInfo]
+    return sessionInfo?.currentEra.toNumber();
+  },
+  [sessionInfo]
   );
 
   const minimumSessionNumber = useMemo(() => {
@@ -105,12 +105,16 @@ function PerformancePage ({ favorites, targets, toggleFavorite }: Props): React.
 
   if (!currentSession) {
     return (
-      <Spinner label={"waiting for the first session"}/>
+      <Spinner label={'waiting for the first session'} />
     );
   }
 
-  let [sessionEra, currentSessionMode] = inputSession ? [{ session: inputSession }, false] : [{ session: currentSession, era: currentEra }, true];
-  console.log("sessionEra", sessionEra);
+  const [sessionEra, currentSessionMode] = inputSession
+    ? [{ session: inputSession }, false]
+    : [{ era: currentEra, session: currentSession }, true];
+
+  console.log('sessionEra', sessionEra);
+
   return (
     <section>
       <Input
@@ -122,11 +126,11 @@ function PerformancePage ({ favorites, targets, toggleFavorite }: Props): React.
         onEnter={_onAdd}
       />
       <Performance
+        currentSessionMode={currentSessionMode}
         favorites={favorites}
         sessionEra={sessionEra}
         targets={targets}
         toggleFavorite={toggleFavorite}
-        currentSessionMode={currentSessionMode}
       />
     </section>
   );

--- a/packages/page-staking/src/Performance/index.tsx
+++ b/packages/page-staking/src/Performance/index.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { DeriveSessionProgress } from '@polkadot/api-derive/types';
 import { useTranslation } from '@polkadot/app-staking/translate';
 import { SortedTargets } from '@polkadot/app-staking/types';
-import { Input } from '@polkadot/react-components';
+import {Input, Spinner} from '@polkadot/react-components';
 import { useApi, useCall } from '@polkadot/react-hooks';
 
 import Performance from './Performance';
@@ -16,6 +16,11 @@ interface Props {
   favorites: string[];
   targets: SortedTargets;
   toggleFavorite: (address: string) => void;
+}
+
+export interface SessionEra {
+  session: number,
+  era?: number,
 }
 
 function PerformancePage ({ favorites, targets, toggleFavorite }: Props): React.ReactElement<Props> {
@@ -33,6 +38,12 @@ function PerformancePage ({ favorites, targets, toggleFavorite }: Props): React.
     return sessionInfo?.currentIndex.toNumber();
   },
   [sessionInfo]
+  );
+
+  const currentEra = useMemo(() => {
+      return sessionInfo?.currentEra.toNumber();
+    },
+    [sessionInfo]
   );
 
   const minimumSessionNumber = useMemo(() => {
@@ -92,6 +103,14 @@ function PerformancePage ({ favorites, targets, toggleFavorite }: Props): React.
   [t, currentSession, minimumSessionNumber]
   );
 
+  if (!currentSession) {
+    return (
+      <Spinner label={"waiting for the first session"}/>
+    );
+  }
+
+  let [sessionEra, currentSessionMode] = inputSession ? [{ session: inputSession }, false] : [{ session: currentSession, era: currentEra }, true];
+  console.log("sessionEra", sessionEra);
   return (
     <section>
       <Input
@@ -102,15 +121,13 @@ function PerformancePage ({ favorites, targets, toggleFavorite }: Props): React.
         onChange={_onChangeKey}
         onEnter={_onAdd}
       />
-      {(!currentSession || !inputSession)
-        ? undefined
-        : (
-          <Performance
-            favorites={favorites}
-            session={inputSession}
-            targets={targets}
-            toggleFavorite={toggleFavorite}
-          />)}
+      <Performance
+        favorites={favorites}
+        sessionEra={sessionEra}
+        targets={targets}
+        toggleFavorite={toggleFavorite}
+        currentSessionMode={currentSessionMode}
+      />
     </section>
   );
 }

--- a/packages/page-staking/src/Performance/index.tsx
+++ b/packages/page-staking/src/Performance/index.tsx
@@ -1,10 +1,15 @@
-import React, {useCallback, useMemo, useState} from "react";
-import {SortedTargets} from "@polkadot/app-staking/types";
-import Performance from "./Performance";
-import {useApi, useCall} from "@polkadot/react-hooks";
-import {DeriveSessionProgress} from "@polkadot/api-derive/types";
-import {Input, Spinner} from "@polkadot/react-components";
-import {useTranslation} from "@polkadot/app-staking/translate";
+// Copyright 2017-2022 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useCallback, useMemo, useState } from 'react';
+
+import { DeriveSessionProgress } from '@polkadot/api-derive/types';
+import { useTranslation } from '@polkadot/app-staking/translate';
+import { SortedTargets } from '@polkadot/app-staking/types';
+import { Input } from '@polkadot/react-components';
+import { useApi, useCall } from '@polkadot/react-hooks';
+
+import Performance from './Performance';
 
 interface Props {
   className?: string;
@@ -13,92 +18,99 @@ interface Props {
   toggleFavorite: (address: string) => void;
 }
 
-function PerformancePage ({ className = '', favorites, targets, toggleFavorite }: Props): React.ReactElement<Props> {
+function PerformancePage ({ favorites, targets, toggleFavorite }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
   const sessionInfo = useCall<DeriveSessionProgress>(api.derive.session.progress);
   const historyDepth = useCall<number>(api.query.staking.historyDepth);
   const [{ isValid, key }, setValue] = useState<{ isValid: boolean; key: string }>(() => ({
     isValid: false,
-    key: '',
+    key: ''
   }));
-  const [ inputSession, setInputSession ] = useState<number | null>(null);
+  const [inputSession, setInputSession] = useState<number | null>(null);
 
-  const currentSession = useMemo( () => {
-      return sessionInfo?.currentIndex.toNumber();
-    },
-    [sessionInfo]
+  const currentSession = useMemo(() => {
+    return sessionInfo?.currentIndex.toNumber();
+  },
+  [sessionInfo]
   );
 
   const minimumSessionNumber = useMemo(() => {
-      if (currentSession && historyDepth && sessionInfo) {
-        return Math.max(currentSession - historyDepth * sessionInfo.sessionsPerEra.toNumber(), 0);
-      }
-      return null;
-    },
-    [historyDepth, currentSession, sessionInfo]
+    if (currentSession && historyDepth && sessionInfo) {
+      return Math.max(currentSession - historyDepth * sessionInfo.sessionsPerEra.toNumber(), 1);
+    }
+
+    return null;
+  },
+  [historyDepth, currentSession, sessionInfo]
   );
 
   const _onChangeKey = useCallback(
     (key: string): void => {
       let valid = false;
+
       if (currentSession && historyDepth && minimumSessionNumber) {
-        let sessionNumber = parseInt(key);
+        const sessionNumber = parseInt(key);
+
         if (!isNaN(sessionNumber)) {
           if (sessionNumber < currentSession && minimumSessionNumber <= sessionNumber) {
             valid = true;
           }
         }
       }
+
       setValue({
         isValid: valid,
-        key: key,
+        key
       });
     },
-    [currentSession, minimumSessionNumber]
+    [currentSession, minimumSessionNumber, historyDepth]
   );
 
   const _onAdd = useCallback(
     (): void => {
       if (isValid) {
-          setInputSession(Number(key));
+        setInputSession(Number(key));
       }
     },
     [isValid, key]
   );
 
   const help = useMemo(() => {
-        let msg = t<string>("Enter past session number.");
-        if (currentSession) {
-          msg += " Current is " + currentSession + ".";
-          if (minimumSessionNumber) {
-            msg += " Minimum session number is " + minimumSessionNumber + ".";
-          }
-        }
-        return msg;
-    },
-    [currentSession, minimumSessionNumber]
-    );
+    let msg = t<string>('Enter past session number.');
+
+    if (currentSession) {
+      msg += ' Current one is ' + currentSession.toString() + '.';
+
+      if (minimumSessionNumber) {
+        msg += ' Minimum session number is ' + minimumSessionNumber.toString() + '.';
+      }
+    }
+
+    return msg;
+  },
+  [t, currentSession, minimumSessionNumber]
+  );
 
   return (
     <section>
-        <Input
-          autoFocus
-          label={t<string>('Session number')}
-          help={help}
-          onChange={_onChangeKey}
-          onEnter={_onAdd}
-          isError={!isValid}
-        />
-      {(!currentSession || !inputSession) ?
-        (<Spinner />) :
-        (<Performance
-          favorites={favorites}
-          targets={targets}
-          toggleFavorite={toggleFavorite}
-          session={inputSession}
-        />)
-      }
+      <Input
+        autoFocus
+        help={help}
+        isError={!isValid}
+        label={t<string>('Session number')}
+        onChange={_onChangeKey}
+        onEnter={_onAdd}
+      />
+      {(!currentSession || !inputSession)
+        ? undefined
+        : (
+          <Performance
+            favorites={favorites}
+            session={inputSession}
+            targets={targets}
+            toggleFavorite={toggleFavorite}
+          />)}
     </section>
   );
 }

--- a/packages/page-staking/src/Performance/index.tsx
+++ b/packages/page-staking/src/Performance/index.tsx
@@ -1,208 +1,106 @@
-// Copyright 2017-2022 @polkadot/app-staking authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
-import type { SortedTargets } from '../types';
-
-import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
-
-import { DeriveSessionProgress } from '@polkadot/api-derive/types';
-import { useApi, useCall } from '@polkadot/react-hooks';
-import { Vec } from '@polkadot/types';
-import {AccountId, EraIndex, Hash} from '@polkadot/types/interfaces';
-import {Option, Struct, u32} from '@polkadot/types-codec';
-
-import ActionsBanner from './ActionsBanner';
-import CurrentList from './CurrentList';
-import Summary from './Summary';
-import {BlockAuthorsContext} from "@polkadot/react-query";
+import React, {useCallback, useMemo, useState} from "react";
+import {SortedTargets} from "@polkadot/app-staking/types";
+import Performance from "./Performance";
+import {useApi, useCall} from "@polkadot/react-hooks";
+import {DeriveSessionProgress} from "@polkadot/api-derive/types";
+import {Input, Spinner} from "@polkadot/react-components";
+import {useTranslation} from "@polkadot/app-staking/translate";
 
 interface Props {
   className?: string;
   favorites: string[];
   targets: SortedTargets;
   toggleFavorite: (address: string) => void;
-  session?: number,
 }
 
-interface CurrentEraValidators extends Struct {
-  reserved: Vec<AccountId>;
-  nonReserved: Vec<AccountId>;
-}
-
-export interface CommitteeSize {
-  nonReservedSeats: u32
-  reservedSeats: u32,
-}
-
-type SessionIndexEntry = [{ args: [EraIndex] }, Option<u32>];
-
-function Performance ({ className = '', favorites, session, targets, toggleFavorite }: Props): React.ReactElement<Props> {
+function PerformancePage ({ className = '', favorites, targets, toggleFavorite }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
   const { api } = useApi();
-  const currentEraValidators = useCall<CurrentEraValidators>(api.query.elections.currentEraValidators);
-  const [sessionValidatorBlockCountLookup, setSessionValidatorBlockCountLookup] = useState({});
-  const committeeSize = useCall<CommitteeSize>(api.query.elections.committeeSize);
   const sessionInfo = useCall<DeriveSessionProgress>(api.derive.session.progress);
-  const [currentSessionCached, setCurrentSessionCached] = useState(0);
-  const sessionChanged = useRef(false);
-  const { lastHeaders } = useContext(BlockAuthorsContext);
-  const [ lastHeaderAuthorCached, setLastHeaderAuthorCached] = useState('');
-  const [firstBlockInSessionHash, setFirstBlockInSessionHash] = useState<Hash | null>(null);
-  const erasStartSessionIndex = useCall<SessionIndexEntry[]>(api.query.staking.erasStartSessionIndex.entries);
+  const historyDepth = useCall<number>(api.query.staking.historyDepth);
+  const [{ isValid, key }, setValue] = useState<{ isValid: boolean; key: string }>(() => ({
+    isValid: false,
+    key: '',
+  }));
+  const [ inputSession, setInputSession ] = useState<number | null>(null);
 
-  // to be used later on
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-
-  const [era, eraFirstSession, eraLastSession]: [number | undefined, number | undefined, number | undefined] = useMemo(
-    () => {
-      console.log('erasStartSessionIndex has changed');
-      if (!sessionInfo || !erasStartSessionIndex) {
-        return [undefined, undefined, undefined];
-      }
-
-      const erasStartSessionIndexLookup: Record<number, number> = {};
-
-      erasStartSessionIndex.filter(([, values]) => values.isSome)
-        .forEach(([key, values]) => {
-          const eraIndex = key.args[0];
-
-          erasStartSessionIndexLookup[eraIndex.toNumber()] = values.unwrap().toNumber();
-        });
-
-      let currentEra = sessionInfo.activeEra.toNumber();
-      let currentEraSessionStart: number = erasStartSessionIndexLookup[currentEra];
-      let currentEraSessionEnd = null;
-      const currentSession = sessionInfo.currentIndex.toNumber();
-
-      while (currentEraSessionStart > currentSession) {
-        currentEraSessionEnd = currentEraSessionStart - 1;
-        currentEra = currentEra - 1;
-        currentEraSessionStart = erasStartSessionIndexLookup[currentEra];
-      }
-
-      console.log(currentEra, currentEraSessionStart, currentEraSessionEnd);
-      return [currentEra, currentEraSessionStart, currentEraSessionEnd];
+  const currentSession = useMemo( () => {
+      return sessionInfo?.currentIndex.toNumber();
     },
-    [erasStartSessionIndex]
+    [sessionInfo]
   );
 
-  useEffect(() => {
-    setTimeout(() => {
-      api && api.query.elections && api.query.elections.sessionValidatorBlockCount &&
-      api.query.elections.sessionValidatorBlockCount.entries().then(
-        (result) => {
-          if (result) {
-            const sessionValidatorBlockCountLookup: Record<string, number> = {};
+  const minimumSessionNumber = useMemo(() => {
+      if (currentSession && historyDepth && sessionInfo) {
+        return Math.max(currentSession - historyDepth * sessionInfo.sessionsPerEra.toNumber(), 0);
+      }
+      return null;
+    },
+    [historyDepth, currentSession, sessionInfo]
+  );
 
-            result.forEach(([key, values]) => {
-              const account = key.args[0].toString();
-
-              sessionValidatorBlockCountLookup[account] = Number(values.toString());
-            });
-            setSessionValidatorBlockCountLookup(sessionValidatorBlockCountLookup);
+  const _onChangeKey = useCallback(
+    (key: string): void => {
+      let valid = false;
+      if (currentSession && historyDepth && minimumSessionNumber) {
+        let sessionNumber = parseInt(key);
+        if (!isNaN(sessionNumber)) {
+          if (sessionNumber < currentSession && minimumSessionNumber <= sessionNumber) {
+            valid = true;
           }
         }
-      ).catch(console.error);
-    }, 1000);
-  });
-
-  useEffect( () => {
-    if (eraFirstSession) {
-      console.log(eraFirstSession);
-      const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
-      let firstBlockInSession = eraFirstSession * sessionPeriod;
-      api.rpc.chain
-        .getBlockHash(firstBlockInSession)
-        .then((result): void => {
-          setFirstBlockInSessionHash(result);
-        })
-        .catch(console.error);
-       }
+      }
+      setValue({
+        isValid: valid,
+        key: key,
+      });
     },
-    [api, eraFirstSession]
+    [currentSession, minimumSessionNumber]
   );
 
-  useEffect(() => {
-    if (firstBlockInSessionHash) {
-      console.log(firstBlockInSessionHash.toString());
-    }
+  const _onAdd = useCallback(
+    (): void => {
+      if (isValid) {
+          setInputSession(Number(key));
+      }
     },
-    [firstBlockInSessionHash]
+    [isValid, key]
   );
 
-  useEffect(() => {
-    let lastHeader = lastHeaders
-          .filter((header) => !!header)[0];
-        if (lastHeader && lastHeader.author) {
-          setLastHeaderAuthorCached(lastHeader.author.toString());
-          if (sessionChanged.current) {
-            console.log(lastHeaderAuthorCached);
-            console.log(currentSessionCached);
-            sessionChanged.current = false;
+  const help = useMemo(() => {
+        let msg = t<string>("Enter past session number.");
+        if (currentSession) {
+          msg += " Current is " + currentSession + ".";
+          if (minimumSessionNumber) {
+            msg += " Minimum session number is " + minimumSessionNumber + ".";
           }
         }
-    }, [lastHeaders]
-  );
-
-
-  const [eraValidators, currentSessionCommittee] = useMemo(
-    () => {
-      if (!currentEraValidators || !sessionInfo || !committeeSize) {
-        return [[], []];
-      }
-      const nonReserved = currentEraValidators.nonReserved.toArray();
-      const reserved = currentEraValidators.reserved.toArray();
-      const nonReservedFreeSeats = committeeSize.nonReservedSeats.toNumber();
-      const reservedFreeSeats = committeeSize.reservedSeats.toNumber();
-      const currentSession = sessionInfo.currentIndex.toNumber();
-
-      const chosenFromNonReserved = chooseForSession(nonReserved, nonReservedFreeSeats, currentSession);
-      const chosenFromReserved = chooseForSession(reserved, reservedFreeSeats, currentSession);
-
-      const currentSessionCommittee = chosenFromReserved.concat(chosenFromNonReserved);
-      const eraValidators = reserved.concat(nonReserved);
-      if (currentSession != currentSessionCached) {
-        sessionChanged.current = true;
-        setCurrentSessionCached(currentSession);
-      }
-
-      return [eraValidators, currentSessionCommittee];
+        return msg;
     },
-    [currentEraValidators, sessionInfo, committeeSize]
-  );
-
-  function chooseForSession (validators: AccountId[], count: number, sessionIndex: number) {
-    const validatorsLength = validators.length;
-    const firstIndex = sessionIndex * count % validatorsLength;
-    const chosen: Array<AccountId> = [];
-
-    for (let i = 0; i < Math.min(count, validatorsLength); i++) {
-      chosen.push(validators[(firstIndex + i) % validatorsLength]);
-    }
-
-    return chosen;
-  }
+    [currentSession, minimumSessionNumber]
+    );
 
   return (
-    <div className={`staking--Performance ${className}`}>
-      <Summary
-        currentSessionCommittee={currentSessionCommittee}
-        eraValidators={eraValidators}
-        targets={targets}
-      />
-      <ActionsBanner />
-      <CurrentList
-        committeeSize={committeeSize}
-        currentSessionCommittee={currentSessionCommittee}
-        favorites={favorites}
-        session={session}
-        sessionInfo={sessionInfo}
-        sessionValidatorBlockCountLookup={sessionValidatorBlockCountLookup}
-        targets={targets}
-        toggleFavorite={toggleFavorite}
-      />
-    </div>
+    <section>
+        <Input
+          autoFocus
+          label={t<string>('Session number')}
+          help={help}
+          onChange={_onChangeKey}
+          onEnter={_onAdd}
+          isError={!isValid}
+        />
+      {(!currentSession || !inputSession) ?
+        (<Spinner />) :
+        (<Performance
+          favorites={favorites}
+          targets={targets}
+          toggleFavorite={toggleFavorite}
+          session={inputSession}
+        />)
+      }
+    </section>
   );
 }
 
-export default React.memo(Performance);
+export default React.memo(PerformancePage);

--- a/packages/page-staking/src/Performance/index.tsx
+++ b/packages/page-staking/src/Performance/index.tsx
@@ -3,16 +3,18 @@
 
 import type { SortedTargets } from '../types';
 
-import React, { useMemo } from 'react';
+import React, {useContext, useEffect, useMemo, useRef, useState} from 'react';
 
+import { DeriveSessionProgress } from '@polkadot/api-derive/types';
 import { useApi, useCall } from '@polkadot/react-hooks';
 import { Vec } from '@polkadot/types';
-import { AccountId } from '@polkadot/types/interfaces';
-import { Struct, u32 } from '@polkadot/types-codec';
+import {AccountId, EraIndex, Hash} from '@polkadot/types/interfaces';
+import {Option, Struct, u32} from '@polkadot/types-codec';
 
 import ActionsBanner from './ActionsBanner';
 import CurrentList from './CurrentList';
 import Summary from './Summary';
+import {BlockAuthorsContext} from "@polkadot/react-query";
 
 interface Props {
   className?: string;
@@ -27,41 +29,159 @@ interface CurrentEraValidators extends Struct {
   nonReserved: Vec<AccountId>;
 }
 
-type SessionValidatorBlockCountEntry = [{ args: [AccountId] }, u32];
+export interface CommitteeSize {
+  nonReservedSeats: u32
+  reservedSeats: u32,
+}
+
+type SessionIndexEntry = [{ args: [EraIndex] }, Option<u32>];
 
 function Performance ({ className = '', favorites, session, targets, toggleFavorite }: Props): React.ReactElement<Props> {
   const { api } = useApi();
   const currentEraValidators = useCall<CurrentEraValidators>(api.query.elections.currentEraValidators);
-  const sessionValidatorBlockCountEntries = useCall<SessionValidatorBlockCountEntry[]>(api.query.elections.sessionValidatorBlockCount.entries);
+  const [sessionValidatorBlockCountLookup, setSessionValidatorBlockCountLookup] = useState({});
+  const committeeSize = useCall<CommitteeSize>(api.query.elections.committeeSize);
+  const sessionInfo = useCall<DeriveSessionProgress>(api.derive.session.progress);
+  const [currentSessionCached, setCurrentSessionCached] = useState(0);
+  const sessionChanged = useRef(false);
+  const { lastHeaders } = useContext(BlockAuthorsContext);
+  const [ lastHeaderAuthorCached, setLastHeaderAuthorCached] = useState('');
+  const [firstBlockInSessionHash, setFirstBlockInSessionHash] = useState<Hash | null>(null);
+  const erasStartSessionIndex = useCall<SessionIndexEntry[]>(api.query.staking.erasStartSessionIndex.entries);
 
-  const sessionValidatorBlockCountLookup = useMemo(
+  // to be used later on
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+
+  const [era, eraFirstSession, eraLastSession]: [number | undefined, number | undefined, number | undefined] = useMemo(
     () => {
-      const sessionValidatorBlockCountLookup: Record<string, number> = {};
+      console.log('erasStartSessionIndex has changed');
+      if (!sessionInfo || !erasStartSessionIndex) {
+        return [undefined, undefined, undefined];
+      }
 
-      sessionValidatorBlockCountEntries?.forEach(([key, values]) => {
-        const account = key.args[0].toString();
+      const erasStartSessionIndexLookup: Record<number, number> = {};
 
-        sessionValidatorBlockCountLookup[account] = values.toNumber();
-      });
+      erasStartSessionIndex.filter(([, values]) => values.isSome)
+        .forEach(([key, values]) => {
+          const eraIndex = key.args[0];
 
-      return sessionValidatorBlockCountLookup;
+          erasStartSessionIndexLookup[eraIndex.toNumber()] = values.unwrap().toNumber();
+        });
+
+      let currentEra = sessionInfo.activeEra.toNumber();
+      let currentEraSessionStart: number = erasStartSessionIndexLookup[currentEra];
+      let currentEraSessionEnd = null;
+      const currentSession = sessionInfo.currentIndex.toNumber();
+
+      while (currentEraSessionStart > currentSession) {
+        currentEraSessionEnd = currentEraSessionStart - 1;
+        currentEra = currentEra - 1;
+        currentEraSessionStart = erasStartSessionIndexLookup[currentEra];
+      }
+
+      console.log(currentEra, currentEraSessionStart, currentEraSessionEnd);
+      return [currentEra, currentEraSessionStart, currentEraSessionEnd];
     },
-    [sessionValidatorBlockCountEntries]
+    [erasStartSessionIndex]
   );
+
+  useEffect(() => {
+    setTimeout(() => {
+      api && api.query.elections && api.query.elections.sessionValidatorBlockCount &&
+      api.query.elections.sessionValidatorBlockCount.entries().then(
+        (result) => {
+          if (result) {
+            const sessionValidatorBlockCountLookup: Record<string, number> = {};
+
+            result.forEach(([key, values]) => {
+              const account = key.args[0].toString();
+
+              sessionValidatorBlockCountLookup[account] = Number(values.toString());
+            });
+            setSessionValidatorBlockCountLookup(sessionValidatorBlockCountLookup);
+          }
+        }
+      ).catch(console.error);
+    }, 1000);
+  });
+
+  useEffect( () => {
+    if (eraFirstSession) {
+      console.log(eraFirstSession);
+      const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
+      let firstBlockInSession = eraFirstSession * sessionPeriod;
+      api.rpc.chain
+        .getBlockHash(firstBlockInSession)
+        .then((result): void => {
+          setFirstBlockInSessionHash(result);
+        })
+        .catch(console.error);
+       }
+    },
+    [api, eraFirstSession]
+  );
+
+  useEffect(() => {
+    if (firstBlockInSessionHash) {
+      console.log(firstBlockInSessionHash.toString());
+    }
+    },
+    [firstBlockInSessionHash]
+  );
+
+  useEffect(() => {
+    let lastHeader = lastHeaders
+          .filter((header) => !!header)[0];
+        if (lastHeader && lastHeader.author) {
+          setLastHeaderAuthorCached(lastHeader.author.toString());
+          if (sessionChanged.current) {
+            console.log(lastHeaderAuthorCached);
+            console.log(currentSessionCached);
+            sessionChanged.current = false;
+          }
+        }
+    }, [lastHeaders]
+  );
+
 
   const [eraValidators, currentSessionCommittee] = useMemo(
     () => {
-      if (!currentEraValidators || !sessionValidatorBlockCountLookup) {
+      if (!currentEraValidators || !sessionInfo || !committeeSize) {
         return [[], []];
       }
+      const nonReserved = currentEraValidators.nonReserved.toArray();
+      const reserved = currentEraValidators.reserved.toArray();
+      const nonReservedFreeSeats = committeeSize.nonReservedSeats.toNumber();
+      const reservedFreeSeats = committeeSize.reservedSeats.toNumber();
+      const currentSession = sessionInfo.currentIndex.toNumber();
 
-      const currentSessionCommittee = Object.keys(sessionValidatorBlockCountLookup);
-      const eraValidators = currentEraValidators?.nonReserved.toArray().concat(currentEraValidators?.reserved.toArray());
+      const chosenFromNonReserved = chooseForSession(nonReserved, nonReservedFreeSeats, currentSession);
+      const chosenFromReserved = chooseForSession(reserved, reservedFreeSeats, currentSession);
+
+      const currentSessionCommittee = chosenFromReserved.concat(chosenFromNonReserved);
+      const eraValidators = reserved.concat(nonReserved);
+      if (currentSession != currentSessionCached) {
+        sessionChanged.current = true;
+        setCurrentSessionCached(currentSession);
+      }
 
       return [eraValidators, currentSessionCommittee];
     },
-    [currentEraValidators, sessionValidatorBlockCountLookup]
+    [currentEraValidators, sessionInfo, committeeSize]
   );
+
+  function chooseForSession (validators: AccountId[], count: number, sessionIndex: number) {
+    const validatorsLength = validators.length;
+    const firstIndex = sessionIndex * count % validatorsLength;
+    const chosen: Array<AccountId> = [];
+
+    for (let i = 0; i < Math.min(count, validatorsLength); i++) {
+      chosen.push(validators[(firstIndex + i) % validatorsLength]);
+    }
+
+    return chosen;
+  }
 
   return (
     <div className={`staking--Performance ${className}`}>
@@ -72,9 +192,11 @@ function Performance ({ className = '', favorites, session, targets, toggleFavor
       />
       <ActionsBanner />
       <CurrentList
+        committeeSize={committeeSize}
         currentSessionCommittee={currentSessionCommittee}
         favorites={favorites}
         session={session}
+        sessionInfo={sessionInfo}
         sessionValidatorBlockCountLookup={sessionValidatorBlockCountLookup}
         targets={targets}
         toggleFavorite={toggleFavorite}

--- a/packages/page-staking/src/index.tsx
+++ b/packages/page-staking/src/index.tsx
@@ -11,7 +11,6 @@ import { Route, Switch } from 'react-router';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
-import Performance from '@polkadot/app-staking/Performance';
 import { HelpOverlay, Tabs } from '@polkadot/react-components';
 import { useAccounts, useApi, useAvailableSlashes, useCall, useCallMulti, useFavorites, useOwnStashInfos } from '@polkadot/react-hooks';
 import { isFunction } from '@polkadot/util';
@@ -30,6 +29,7 @@ import useNominations from './useNominations';
 import useOwnPools from './useOwnPools';
 import useSortedTargets from './useSortedTargets';
 import Validators from './Validators';
+import PerformancePage from "@polkadot/app-staking/Performance";
 
 const HIDDEN_ACC = ['actions', 'payout'];
 
@@ -200,7 +200,7 @@ function StakingApp ({ basePath, className = '' }: Props): React.ReactElement<Pr
           />
         </Route>
         <Route path={pathRef.current.performance}>
-          <Performance
+          <PerformancePage
             favorites={favorites}
             targets={targets}
             toggleFavorite={toggleFavorite}

--- a/packages/page-staking/src/index.tsx
+++ b/packages/page-staking/src/index.tsx
@@ -202,7 +202,6 @@ function StakingApp ({ basePath, className = '' }: Props): React.ReactElement<Pr
         <Route path={pathRef.current.performance}>
           <PerformancePage
             favorites={favorites}
-            targets={targets}
             toggleFavorite={toggleFavorite}
           />
         </Route>

--- a/packages/page-staking/src/index.tsx
+++ b/packages/page-staking/src/index.tsx
@@ -11,6 +11,7 @@ import { Route, Switch } from 'react-router';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
+import PerformancePage from '@polkadot/app-staking/Performance';
 import { HelpOverlay, Tabs } from '@polkadot/react-components';
 import { useAccounts, useApi, useAvailableSlashes, useCall, useCallMulti, useFavorites, useOwnStashInfos } from '@polkadot/react-hooks';
 import { isFunction } from '@polkadot/util';
@@ -29,7 +30,6 @@ import useNominations from './useNominations';
 import useOwnPools from './useOwnPools';
 import useSortedTargets from './useSortedTargets';
 import Validators from './Validators';
-import PerformancePage from "@polkadot/app-staking/Performance";
 
 const HIDDEN_ACC = ['actions', 'payout'];
 


### PR DESCRIPTION
This PR introduces more features into a new Staking/Performance page:
* calculation of % reward, including lenient uptime,
* current block column is updated in real-time,
* historical past session mode - it is possible to query past session from `N - 1` to `N - palletStaking.historyPeriod * 96
* current session mode 
* expected number of blocks is calculated based on first session block author
* toggle to switch the display between current session committee and all era validators
* checking if the first block of a session contains pallet elections with storage versions at least 3 
