### PR TITLE
A0 1333 performance per validator

### DIFF
--- a/packages/page-staking/src/Performance/Address/index.tsx
+++ b/packages/page-staking/src/Performance/Address/index.tsx
@@ -1,24 +1,21 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useMemo } from 'react';
+import React, {useCallback, useMemo} from 'react';
 
 import { ApiPromise } from '@polkadot/api';
-import { AddressSmall } from '@polkadot/react-components';
+import {AddressSmall, Icon, Spinner} from '@polkadot/react-components';
 import { checkVisibility } from '@polkadot/react-components/util';
 import { useApi, useDeriveAccountInfo } from '@polkadot/react-hooks';
-
-import Favorite from './Favorite';
+import {queryAddress} from "@polkadot/app-staking/Targets/Validator";
 
 interface Props {
   address: string;
   filterName: string;
-  isFavorite?: boolean;
-  toggleFavorite?: (accountId: string) => void;
   session?: number;
-  blocksCreated: number,
+  blocksCreated?: number,
   blocksTarget: number,
-  rewardPercentage: string,
+  rewardPercentage?: string,
 }
 
 function useAddressCalls (api: ApiPromise, address: string) {
@@ -27,7 +24,7 @@ function useAddressCalls (api: ApiPromise, address: string) {
   return { accountInfo };
 }
 
-function Address ({ address, session, blocksCreated, blocksTarget, filterName, isFavorite, rewardPercentage, toggleFavorite }: Props): React.ReactElement<Props> | null {
+function Address ({ address, session, blocksCreated, blocksTarget, filterName, rewardPercentage, }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
   const { accountInfo } = useAddressCalls(api, address);
 
@@ -40,15 +37,13 @@ function Address ({ address, session, blocksCreated, blocksTarget, filterName, i
     return null;
   }
 
+  const _onQueryStats = useCallback(
+    () => queryAddress(address),
+    [address]
+  );
+
   return (
     <tr>
-      <td className='badge together'>
-       <Favorite
-          address={address}
-          isFavorite={isFavorite}
-          toggleFavorite={toggleFavorite}
-        />
-      </td>
       <td className='address'>
         <AddressSmall value={address} />
       </td>
@@ -56,15 +51,21 @@ function Address ({ address, session, blocksCreated, blocksTarget, filterName, i
         {session}
       </td>}
       <td className='number'>
-        {blocksCreated}
+        {blocksCreated === undefined ? <Spinner noLabel={true}/> : blocksCreated}
       </td>
       <td className='number'>
         {blocksTarget}
       </td>
       <td className='number'>
-        {rewardPercentage}
+        {blocksCreated === undefined ? '' : rewardPercentage}
       </td>
-
+      {!session && <td className='number'>
+        <Icon
+          className='staking--stats highlight--color'
+          icon='chart-line'
+          onClick={_onQueryStats}
+        />
+      </td>}
     </tr>
   );
 }

--- a/packages/page-staking/src/Performance/Address/index.tsx
+++ b/packages/page-staking/src/Performance/Address/index.tsx
@@ -1,13 +1,12 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, {useCallback, useMemo} from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { ApiPromise } from '@polkadot/api';
-import {AddressSmall, Icon, Spinner} from '@polkadot/react-components';
+import { AddressSmall, Icon, Spinner } from '@polkadot/react-components';
 import { checkVisibility } from '@polkadot/react-components/util';
 import { useApi, useDeriveAccountInfo } from '@polkadot/react-hooks';
-import {queryAddress} from "@polkadot/app-staking/Targets/Validator";
 
 interface Props {
   address: string;
@@ -24,7 +23,11 @@ function useAddressCalls (api: ApiPromise, address: string) {
   return { accountInfo };
 }
 
-function Address ({ address, session, blocksCreated, blocksTarget, filterName, rewardPercentage, }: Props): React.ReactElement<Props> | null {
+function queryAddress (address: string): void {
+  window.location.hash = `/staking/query/${address}`;
+}
+
+function Address ({ address, blocksCreated, blocksTarget, filterName, rewardPercentage, session }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
   const { accountInfo } = useAddressCalls(api, address);
 
@@ -37,6 +40,7 @@ function Address ({ address, session, blocksCreated, blocksTarget, filterName, r
     return null;
   }
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const _onQueryStats = useCallback(
     () => queryAddress(address),
     [address]
@@ -51,7 +55,7 @@ function Address ({ address, session, blocksCreated, blocksTarget, filterName, r
         {session}
       </td>}
       <td className='number'>
-        {blocksCreated === undefined ? <Spinner noLabel={true}/> : blocksCreated}
+        {blocksCreated === undefined ? <Spinner noLabel={true} /> : blocksCreated}
       </td>
       <td className='number'>
         {blocksTarget}

--- a/packages/page-staking/src/Performance/Address/index.tsx
+++ b/packages/page-staking/src/Performance/Address/index.tsx
@@ -23,7 +23,7 @@ function useAddressCalls (api: ApiPromise, address: string) {
   return { accountInfo };
 }
 
-function queryAddress (address: string): void {
+function queryAddress (address: string) {
   window.location.hash = `/staking/query/${address}`;
 }
 
@@ -41,7 +41,7 @@ function Address ({ address, blocksCreated, blocksTarget, filterName, rewardPerc
   }
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const _onQueryStats = useCallback(
+  const onQueryStats = useCallback(
     () => queryAddress(address),
     [address]
   );
@@ -55,7 +55,7 @@ function Address ({ address, blocksCreated, blocksTarget, filterName, rewardPerc
         {session}
       </td>}
       <td className='number'>
-        {blocksCreated === undefined ? <Spinner noLabel={true} /> : blocksCreated}
+        {blocksCreated ?? <Spinner noLabel={true} />}
       </td>
       <td className='number'>
         {blocksTarget}
@@ -67,7 +67,7 @@ function Address ({ address, blocksCreated, blocksTarget, filterName, rewardPerc
         <Icon
           className='staking--stats highlight--color'
           icon='chart-line'
-          onClick={_onQueryStats}
+          onClick={onQueryStats}
         />
       </td>}
     </tr>

--- a/packages/page-staking/src/Performance/Address/index.tsx
+++ b/packages/page-staking/src/Performance/Address/index.tsx
@@ -12,10 +12,10 @@ import Favorite from './Favorite';
 
 interface Props {
   address: string;
-  className?: string;
   filterName: string;
-  isFavorite: boolean;
-  toggleFavorite: (accountId: string) => void;
+  isFavorite?: boolean;
+  toggleFavorite?: (accountId: string) => void;
+  session?: number;
   blocksCreated: number,
   blocksTarget: number,
   rewardPercentage: string,
@@ -27,7 +27,7 @@ function useAddressCalls (api: ApiPromise, address: string) {
   return { accountInfo };
 }
 
-function Address ({ address, blocksCreated, blocksTarget, className = '', filterName, isFavorite, rewardPercentage, toggleFavorite }: Props): React.ReactElement<Props> | null {
+function Address ({ address, session, blocksCreated, blocksTarget, filterName, isFavorite, rewardPercentage, toggleFavorite }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
   const { accountInfo } = useAddressCalls(api, address);
 
@@ -41,9 +41,9 @@ function Address ({ address, blocksCreated, blocksTarget, className = '', filter
   }
 
   return (
-    <tr className={className}>
+    <tr>
       <td className='badge together'>
-        <Favorite
+       <Favorite
           address={address}
           isFavorite={isFavorite}
           toggleFavorite={toggleFavorite}
@@ -52,6 +52,9 @@ function Address ({ address, blocksCreated, blocksTarget, className = '', filter
       <td className='address'>
         <AddressSmall value={address} />
       </td>
+      {session && <td className='number'>
+        {session}
+      </td>}
       <td className='number'>
         {blocksCreated}
       </td>

--- a/packages/page-staking/src/Performance/CurrentList.tsx
+++ b/packages/page-staking/src/Performance/CurrentList.tsx
@@ -32,6 +32,7 @@ export function calculatePercentReward (blocksCreated: number | undefined, block
 
   if (blocksTargetValue > 0) {
     rewardPercentage = 100 * blocksCreated / blocksTargetValue;
+
     if (rewardPercentage >= 90 && rewardPercentage <= 100) {
       rewardPercentage = 100;
     }

--- a/packages/page-staking/src/Performance/CurrentList.tsx
+++ b/packages/page-staking/src/Performance/CurrentList.tsx
@@ -3,13 +3,13 @@
 
 import React, { useMemo, useRef, useState } from 'react';
 
+import { EraValidatorPerformance } from '@polkadot/app-staking/Performance/Performance';
 import { Table, Toggle } from '@polkadot/react-components';
 import { useLoadingDelay } from '@polkadot/react-hooks';
 
 import Filtering from '../Filtering';
 import { useTranslation } from '../translate';
 import Address from './Address';
-import {EraValidatorPerformance} from "@polkadot/app-staking/Performance/Performance";
 
 interface Props {
   className?: string;
@@ -19,6 +19,7 @@ interface Props {
 
 function getFiltered (displayOnlyCommittee: boolean, eraValidatorPerformances: EraValidatorPerformance[]) {
   const validators = displayOnlyCommittee ? eraValidatorPerformances.filter((performance) => performance.isCommittee) : eraValidatorPerformances;
+
   return validators;
 }
 
@@ -26,6 +27,7 @@ export function calculatePercentReward (blocksCreated: number | undefined, block
   if (blocksCreated === undefined) {
     return '';
   }
+
   let rewardPercentage = 0;
 
   if (blocksTargetValue > 0) {
@@ -66,9 +68,10 @@ function CurrentList ({ className, eraValidatorPerformances }: Props): React.Rea
       [t('blocks created'), 'expand'],
       [t('blocks expected'), 'expand'],
       [t('max % reward'), 'expand'],
-      [t('stats'), 'expand'],
+      [t('stats'), 'expand']
     ]
   );
+
   return (
     <Table
       className={className}
@@ -99,7 +102,7 @@ function CurrentList ({ className, eraValidatorPerformances }: Props): React.Rea
       }
       header={headerRef.current}
     >
-      {list.map(({validatorPerformance}): React.ReactNode => (
+      {list.map(({ validatorPerformance }): React.ReactNode => (
         <Address
           address={validatorPerformance.accountId}
           blocksCreated={validatorPerformance.blockCount}

--- a/packages/page-staking/src/Performance/CurrentList.tsx
+++ b/packages/page-staking/src/Performance/CurrentList.tsx
@@ -32,7 +32,7 @@ export function calculatePercentReward (blocksCreated: number | undefined, block
 
   if (blocksTargetValue > 0) {
     rewardPercentage = 100 * blocksCreated / blocksTargetValue;
-    if (rewardPercentage >= 90 || rewardPercentage > 100) {
+    if (rewardPercentage >= 90 && rewardPercentage <= 100) {
       rewardPercentage = 100;
     }
   } else if (blocksTargetValue === 0 && blocksCreated === 0) {

--- a/packages/page-staking/src/Performance/CurrentList.tsx
+++ b/packages/page-staking/src/Performance/CurrentList.tsx
@@ -43,6 +43,22 @@ function getFiltered (displayOnlyCommittee: boolean, eraValidatorPerformances: E
   ));
 }
 
+export function calculatePercentReward (blocksCreated: number, blocksTargetValue: number) {
+  let rewardPercentage = 0;
+
+  if (blocksTargetValue > 0) {
+    rewardPercentage = 100 * blocksCreated / blocksTargetValue;
+
+    if (rewardPercentage >= 90) {
+      rewardPercentage = 100;
+    }
+  } else if (blocksTargetValue === 0 && blocksCreated === 0) {
+    rewardPercentage = 100;
+  }
+
+  return rewardPercentage;
+}
+
 function CurrentList ({ className, toggleFavorite, favorites, eraValidatorPerformances }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const [nameFilter, setNameFilter] = useState<string>('');
@@ -72,22 +88,6 @@ function CurrentList ({ className, toggleFavorite, favorites, eraValidatorPerfor
       [undefined, 'media--1200']
     ]
   );
-
-  function calculatePercentReward (blocksCreated: number, blocksTargetValue: number) {
-    let rewardPercentage = 0;
-
-    if (blocksTargetValue > 0) {
-      rewardPercentage = 100 * blocksCreated / blocksTargetValue;
-
-      if (rewardPercentage >= 90) {
-        rewardPercentage = 100;
-      }
-    } else if (blocksTargetValue === 0 && blocksCreated === 0) {
-      rewardPercentage = 100;
-    }
-
-    return rewardPercentage;
-  }
 
   return (
     <Table

--- a/packages/page-staking/src/Performance/CurrentList.tsx
+++ b/packages/page-staking/src/Performance/CurrentList.tsx
@@ -33,7 +33,7 @@ export function calculatePercentReward (blocksCreated: number | undefined, block
   if (blocksTargetValue > 0) {
     rewardPercentage = 100 * blocksCreated / blocksTargetValue;
 
-    if (rewardPercentage >= 90 && rewardPercentage <= 100) {
+    if (rewardPercentage >= 90) {
       rewardPercentage = 100;
     }
   } else if (blocksTargetValue === 0 && blocksCreated === 0) {

--- a/packages/page-staking/src/Performance/CurrentList.tsx
+++ b/packages/page-staking/src/Performance/CurrentList.tsx
@@ -32,8 +32,7 @@ export function calculatePercentReward (blocksCreated: number | undefined, block
 
   if (blocksTargetValue > 0) {
     rewardPercentage = 100 * blocksCreated / blocksTargetValue;
-
-    if (rewardPercentage >= 90) {
+    if (rewardPercentage >= 90 || rewardPercentage > 100) {
       rewardPercentage = 100;
     }
   } else if (blocksTargetValue === 0 && blocksCreated === 0) {

--- a/packages/page-staking/src/Performance/CurrentList.tsx
+++ b/packages/page-staking/src/Performance/CurrentList.tsx
@@ -3,47 +3,47 @@
 
 import React, { useMemo, useRef, useState } from 'react';
 
-import { ValidatorPerformance } from '@polkadot/app-staking/Performance/Performance';
 import { Table, Toggle } from '@polkadot/react-components';
 import { useLoadingDelay } from '@polkadot/react-hooks';
 
 import Filtering from '../Filtering';
 import { useTranslation } from '../translate';
 import Address from './Address';
+import {EraValidatorPerformance} from "@polkadot/app-staking/Performance/Performance";
 
 interface Props {
   className?: string;
   toggleFavorite: (address: string) => void;
   favorites: string[];
   session: number;
-  validatorPerformances: ValidatorPerformance[];
+  eraValidatorPerformances: EraValidatorPerformance[];
 }
 
-interface ValidatorPerformanceExtended {
-  validatorPerformance: ValidatorPerformance;
+interface EraValidatorPerformanceExtended {
+  eraValidatorPerformance: EraValidatorPerformance;
   isFavourite: boolean;
 }
 
-function sortValidatorsByFavourites (validatorPerformances: ValidatorPerformanceExtended[]): ValidatorPerformanceExtended[] {
+function sortValidatorsByFavourites (validatorPerformances: EraValidatorPerformanceExtended[]): EraValidatorPerformanceExtended[] {
   return validatorPerformances
     .sort(({ isFavourite: favA }, { isFavourite: favB }): number => {
       return favA === favB ? 0 : (favA ? -1 : 1);
     });
 }
 
-function getFiltered (displayOnlyCommittee: boolean, validatorPerformances: ValidatorPerformance[], favorites: string[]) {
-  const validators = displayOnlyCommittee ? validatorPerformances.filter((performance) => performance.isCommittee) : validatorPerformances;
+function getFiltered (displayOnlyCommittee: boolean, eraValidatorPerformances: EraValidatorPerformance[], favorites: string[]) {
+  const validators = displayOnlyCommittee ? eraValidatorPerformances.filter((performance) => performance.isCommittee) : eraValidatorPerformances;
 
   return sortValidatorsByFavourites(validators.map((validatorPerformance) => {
       return {
-        isFavourite: !!favorites.find(([id]) => id === validatorPerformance.accountId),
-        validatorPerformance: validatorPerformance,
+        isFavourite: !!favorites.find(([id]) => id === validatorPerformance.validatorPerformance.accountId),
+        eraValidatorPerformance: validatorPerformance,
       };
     }
   ));
 }
 
-function CurrentList ({ className, toggleFavorite, favorites, validatorPerformances }: Props): React.ReactElement<Props> {
+function CurrentList ({ className, toggleFavorite, favorites, eraValidatorPerformances }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const [nameFilter, setNameFilter] = useState<string>('');
   const [displayOnlyCommittee, setDisplayOnlyCommittee] = useState(true);
@@ -51,8 +51,8 @@ function CurrentList ({ className, toggleFavorite, favorites, validatorPerforman
   const isLoading = useLoadingDelay();
 
   const validators = useMemo(
-    () => getFiltered(displayOnlyCommittee, validatorPerformances, favorites),
-    [validatorPerformances, displayOnlyCommittee]
+    () => getFiltered(displayOnlyCommittee, eraValidatorPerformances, favorites),
+    [eraValidatorPerformances, displayOnlyCommittee]
   );
 
   const list = useMemo(
@@ -119,15 +119,15 @@ function CurrentList ({ className, toggleFavorite, favorites, validatorPerforman
       }
       header={headerRef.current}
     >
-      {list.map((performance): React.ReactNode => (
+      {list.map(({eraValidatorPerformance, isFavourite}): React.ReactNode => (
         <Address
-          address={performance.validatorPerformance.accountId}
-          blocksCreated={performance.validatorPerformance.blockCount}
-          blocksTarget={performance.validatorPerformance.expectedBlockCount}
+          address={eraValidatorPerformance.validatorPerformance.accountId}
+          blocksCreated={eraValidatorPerformance.validatorPerformance.blockCount}
+          blocksTarget={eraValidatorPerformance.validatorPerformance.expectedBlockCount}
           filterName={nameFilter}
-          isFavorite={performance.isFavourite}
-          key={performance.validatorPerformance.accountId}
-          rewardPercentage={calculatePercentReward(performance.validatorPerformance.blockCount, performance.validatorPerformance.expectedBlockCount).toFixed(1)}
+          isFavorite={isFavourite}
+          key={eraValidatorPerformance.validatorPerformance.accountId}
+          rewardPercentage={calculatePercentReward(eraValidatorPerformance.validatorPerformance.blockCount, eraValidatorPerformance.validatorPerformance.expectedBlockCount).toFixed(1)}
           toggleFavorite={toggleFavorite}
         />
       ))}

--- a/packages/page-staking/src/Performance/Performance.tsx
+++ b/packages/page-staking/src/Performance/Performance.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, {useMemo} from 'react';
+import React, {useEffect, useMemo} from 'react';
 
 import { MarkWarning, Spinner } from '@polkadot/react-components';
 
@@ -29,6 +29,7 @@ function Performance ({ favorites, sessionEra, toggleFavorite }: Props): React.R
 
   const sessionCommitteePerformance = useSessionCommitteePerformance([sessionEra.session])[0];
   const isPalletElectionsSupported = sessionCommitteePerformance.isPalletElectionsSupported;
+  // const firstBlockAuthor = sessionCommitteePerformance.firstSessionBlockAuthor;
 
   const eraExposure = useCall<DeriveEraExposure>(api.derive.staking.eraExposure, [sessionEra.era]);
   const eraValidators = useMemo(() => {
@@ -66,6 +67,20 @@ function Performance ({ favorites, sessionEra, toggleFavorite }: Props): React.R
     [sessionCommitteePerformance, eraValidators]
 
   );
+
+  // useEffect(() => {
+  //   const interval = setInterval(() => {
+  //     if (firstSessionBlockAuthors) {
+  //       api && api.query.elections && api.query.elections.sessionValidatorBlockCount &&
+  //       api.query.elections.sessionValidatorBlockCount.entries().then((value) => {
+  //         setSessionValidatorBlockCountLookup(parseSessionBlockCount(value, firstSessionBlockAuthors));
+  //       }
+  //       ).catch(console.error);
+  //     }
+  //   }, 1000);
+  //
+  //   return () => clearInterval(interval);
+  // }, [firstSessionBlockAuthors, sessions[0], api]);
 
   return (
     <div className='staking--Performance'>

--- a/packages/page-staking/src/Performance/Performance.tsx
+++ b/packages/page-staking/src/Performance/Performance.tsx
@@ -9,10 +9,10 @@ import ActionsBanner from './ActionsBanner';
 import CurrentList from './CurrentList';
 import { SessionEra } from './index';
 import Summary from './Summary';
-import useValidatorPerformance from "@polkadot/app-staking/Performance/useValidatorPerformance";
+import useSessionValidatorPerformance from './useValidatorPerformance';
 
 interface Props {
-  favorites: string[];
+  favorites: string[],
   toggleFavorite: (address: string) => void;
   sessionEra: SessionEra,
 }
@@ -22,12 +22,13 @@ export interface ValidatorPerformance {
   blockCount: number,
   expectedBlockCount: number,
   isCommittee: boolean;
-  isFavourite: boolean,
 }
 
 function Performance ({ favorites, sessionEra, toggleFavorite }: Props): React.ReactElement<Props>  {
 
-  const [validatorPerformances, committee, isPalletElectionsSupported] = useValidatorPerformance({favorites, sessionEra});
+  const sessionValidatorPerformance = useSessionValidatorPerformance(sessionEra)[0];
+  const isPalletElectionsSupported = sessionValidatorPerformance.isPalletElectionsSupported;
+  const validatorPerformances = sessionValidatorPerformance.validatorPerformances;
 
   return (
     <div className='staking--Performance'>
@@ -40,7 +41,7 @@ function Performance ({ favorites, sessionEra, toggleFavorite }: Props): React.R
       {isPalletElectionsSupported &&
          (<>
            <Summary
-             committee={committee}
+             committee={validatorPerformances.filter((perf) => perf.isCommittee).map((perf) => perf.accountId)}
              era={sessionEra.era}
              session={sessionEra.session}
              validatorPerformances={validatorPerformances}
@@ -49,6 +50,7 @@ function Performance ({ favorites, sessionEra, toggleFavorite }: Props): React.R
            <CurrentList
              session={sessionEra.session}
              toggleFavorite={toggleFavorite}
+             favorites={favorites}
              validatorPerformances={validatorPerformances}
            />
          </>)}

--- a/packages/page-staking/src/Performance/Performance.tsx
+++ b/packages/page-staking/src/Performance/Performance.tsx
@@ -22,7 +22,7 @@ export interface EraValidatorPerformance {
   isCommittee: boolean;
 }
 
-function parsePerformanceCommittee(currentSessionMode: boolean, sessionValidatorBlockCountLookup: [string, number][], committeePerformance: ValidatorPerformance) {
+function parsePerformanceCommittee (currentSessionMode: boolean, sessionValidatorBlockCountLookup: [string, number][], committeePerformance: ValidatorPerformance) {
   if (currentSessionMode && sessionValidatorBlockCountLookup.length > 0) {
     const maybeBlockCount = sessionValidatorBlockCountLookup.find(([id]) => id === committeePerformance.accountId);
     const blockCount = maybeBlockCount ? maybeBlockCount[1] : 0;
@@ -72,8 +72,9 @@ function Performance ({ sessionEra }: Props): React.ReactElement<Props> {
 
   const eraValidatorPerformances: EraValidatorPerformance[] = useMemo(() => {
     if (!sessionCommitteePerformance) {
-        return [];
+      return [];
     }
+
     const committeePerformances = sessionCommitteePerformance.performance;
 
     const validatorPerformancesCommittee = committeePerformances.map((committeePerformance) =>
@@ -93,7 +94,6 @@ function Performance ({ sessionEra }: Props): React.ReactElement<Props> {
     });
 
     return validatorPerformancesCommittee.concat(validatorPerformancesNonCommittee);
-
   },
   [sessionCommitteePerformance, eraValidators, sessionValidatorBlockCountLookup, sessionEra]
 

--- a/packages/page-staking/src/Performance/Performance.tsx
+++ b/packages/page-staking/src/Performance/Performance.tsx
@@ -1,22 +1,17 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React from 'react';
 
-import { DeriveEraExposure } from '@polkadot/api-derive/types';
 import { MarkWarning, Spinner } from '@polkadot/react-components';
-import { useApi, useCall } from '@polkadot/react-hooks';
-import { StorageKey } from '@polkadot/types';
-import { Hash } from '@polkadot/types/interfaces';
-import { AnyTuple, Codec } from '@polkadot/types/types';
 
 import ActionsBanner from './ActionsBanner';
 import CurrentList from './CurrentList';
 import { SessionEra } from './index';
 import Summary from './Summary';
+import useValidatorPerformance from "@polkadot/app-staking/Performance/useValidatorPerformance";
 
 interface Props {
-  className?: string;
   favorites: string[];
   toggleFavorite: (address: string) => void;
   sessionEra: SessionEra,
@@ -30,206 +25,12 @@ export interface ValidatorPerformance {
   isFavourite: boolean,
 }
 
-function Performance ({ className = '', favorites, sessionEra, toggleFavorite }: Props): React.ReactElement<Props> {
-  const { api } = useApi();
+function Performance ({ favorites, sessionEra, toggleFavorite }: Props): React.ReactElement<Props>  {
 
-  const [validatorPerformances, setValidatorPerformances] = useState<ValidatorPerformance[]>([]);
-  const [committee, setCommittee] = useState<string[]>([]);
-
-  const [firstBlockInSessionHash, setFirstBlockInSessionHash] = useState<Hash | undefined>(undefined);
-  const [lastBlockInSessionHash, setLastBlockInSessionHash] = useState<Hash | undefined>(undefined);
-  const [firstSessionBlockAuthor, setFirstSessionBlockAuthor] = useState<string | undefined>(undefined);
-  const [isPalletElectionsSupported, setIsPalletElectionsSupported] = useState<boolean | undefined>(undefined);
-
-  const [sessionValidatorBlockCountLookup, setSessionValidatorBlockCountLookup] = useState<[string, number][]>([]);
-
-  const MINIMUM_SUPPORTED_ELECTIONS_PALLET_VERSION = 3;
-
-  const eraExposure = useCall<DeriveEraExposure>(api.derive.staking.eraExposure, [sessionEra.era]);
-
-  const eraValidators = useMemo(() => {
-    if (eraExposure?.validators) {
-      return Object.keys(eraExposure?.validators);
-    }
-
-    return [];
-  }, [eraExposure]
-  );
-
-  useEffect(() => {
-    const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
-    const firstBlockInSession = sessionEra.session * sessionPeriod;
-
-    api.rpc.chain
-      .getBlockHash(firstBlockInSession)
-      .then((result): void => {
-        setFirstBlockInSessionHash(result);
-      })
-      .catch(console.error);
-  },
-  [api, sessionEra]
-  );
-
-  useEffect(() => {
-    if (firstBlockInSessionHash) {
-      api.at(firstBlockInSessionHash.toString()).then((result) => {
-        result.query.elections.palletVersion().then((version) => {
-          setIsPalletElectionsSupported(Number(version.toString()) >= MINIMUM_SUPPORTED_ELECTIONS_PALLET_VERSION);
-        }).catch(console.error);
-      }).catch(console.error);
-    }
-  }, [api, firstBlockInSessionHash]);
-
-  useEffect(() => {
-    if (!sessionEra.currentSessionMode) {
-      const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
-      const lastBlockInSession = (sessionEra.session + 1) * sessionPeriod - 1;
-
-      api.rpc.chain
-        .getBlockHash(lastBlockInSession)
-        .then((result): void => {
-          setLastBlockInSessionHash(result);
-        })
-        .catch(console.error);
-    }
-  },
-  [api, sessionEra]
-  );
-
-  useEffect(() => {
-    if (firstBlockInSessionHash) {
-      api.derive.chain.getHeader(firstBlockInSessionHash).then((header) => {
-        if (header && !header.isEmpty && header.author) {
-          setFirstSessionBlockAuthor(header.author.toString());
-        }
-      }).catch(console.error);
-    }
-  },
-  [api, firstBlockInSessionHash]
-  );
-
-  function parseSessionBlockCount (sessionValidatorBlockCountValue: [StorageKey<AnyTuple>, Codec][], firstSessionBlockAuthor: string): [string, number][] {
-    return sessionValidatorBlockCountValue.map(([key, values]) => {
-      const account = key.args[0].toString();
-      let count = Number(values.toString());
-
-      if (account === firstSessionBlockAuthor) {
-        // a workaround for the fact that the first session block author is not reflected in that block
-        // elections.sessionValidatorBlockCount state
-        count += 1;
-      }
-
-      return [account, count];
-    });
-  }
-
-  useEffect(() => {
-    if (lastBlockInSessionHash && firstSessionBlockAuthor) {
-      api.at(lastBlockInSessionHash.toString()).then((result) => {
-        const sessionValidatorBlockCount = result.query.elections.sessionValidatorBlockCount;
-
-        sessionValidatorBlockCount && sessionValidatorBlockCount.entries().then((value) => {
-          setSessionValidatorBlockCountLookup(parseSessionBlockCount(value, firstSessionBlockAuthor));
-        }).catch(console.error);
-      }).catch(console.error);
-    }
-  }
-  , [api, lastBlockInSessionHash, firstSessionBlockAuthor]
-  );
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      if (sessionEra.currentSessionMode && firstSessionBlockAuthor) {
-        api && api.query.elections && api.query.elections.sessionValidatorBlockCount &&
-        api.query.elections.sessionValidatorBlockCount.entries().then((value) => {
-          setSessionValidatorBlockCountLookup(parseSessionBlockCount(value, firstSessionBlockAuthor));
-        }
-        ).catch(console.error);
-      }
-    }, 1000);
-
-    return () => clearInterval(interval);
-  }, [firstSessionBlockAuthor, sessionEra, api]);
-
-  useEffect(() => {
-    if (firstBlockInSessionHash) {
-      api.at(firstBlockInSessionHash.toString()).then((resultApi) => {
-        const validators = resultApi.query.session.validators;
-
-        validators && validators().then((value) => {
-          setCommittee(value.map((validator) => validator.toString()));
-        }).catch(console.error);
-      }).catch(console.error);
-    }
-  }, [api, firstBlockInSessionHash]
-  );
-
-  const expectedSessionValidatorBlockCount = useMemo(() => {
-    const result: [string, number][] = [];
-
-    // should not change at all during runtime, therefore it's fine to use current api object
-    const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
-
-    const index = committee.findIndex((value) => value.toString() === firstSessionBlockAuthor);
-
-    if (index === -1) {
-      return [];
-    }
-
-    for (let i = 0; i < committee.length; i++) {
-      const author = committee[(i + index) % committee.length];
-      const offset = Math.max(sessionPeriod - i, 0);
-
-      result.push([author.toString(), Math.ceil(offset / committee.length)]);
-    }
-
-    return result;
-  },
-  [api, firstSessionBlockAuthor, committee]
-  );
-
-  function getValidatorPerformance (validator: string,
-    sessionValidatorBlockCountLookup: [string, number][],
-    expectedSessionValidatorBlockCount: [string, number][],
-    favorites: string[],
-    isCommittee: boolean): ValidatorPerformance {
-    const maybeCount = sessionValidatorBlockCountLookup.find(([id]) => id === validator);
-    const count = maybeCount ? maybeCount[1] : 0;
-    const maybeExpectedBlockCount = expectedSessionValidatorBlockCount.find(([id]) => id === validator);
-    const expectedBlockCount = maybeExpectedBlockCount ? maybeExpectedBlockCount[1] : 0;
-    const isFavourite = !!favorites.find((value) => validator === value);
-
-    return {
-      accountId: validator,
-      blockCount: count,
-      expectedBlockCount,
-      isCommittee,
-      isFavourite
-    };
-  }
-
-  useEffect(() => {
-    const nonCommittee = eraValidators.filter((validator) => !committee.find((value) => validator === value));
-
-    const nonCommitteePerformances = nonCommittee.map((validator) => getValidatorPerformance(validator,
-      sessionValidatorBlockCountLookup,
-      expectedSessionValidatorBlockCount,
-      favorites,
-      false));
-    const committeePerformances = committee.map((validator) => getValidatorPerformance(validator,
-      sessionValidatorBlockCountLookup,
-      expectedSessionValidatorBlockCount,
-      favorites,
-      true));
-
-    setValidatorPerformances(committeePerformances.concat(nonCommitteePerformances));
-  },
-  [committee, eraValidators, sessionValidatorBlockCountLookup, expectedSessionValidatorBlockCount, favorites]
-
-  );
+  const [validatorPerformances, committee, isPalletElectionsSupported] = useValidatorPerformance({favorites, sessionEra});
 
   return (
-    <div className={`staking--Performance ${className}`}>
+    <div className='staking--Performance'>
       {isPalletElectionsSupported === undefined && <Spinner label={'Checking storage version'} />}
       {!isPalletElectionsSupported !== undefined && !isPalletElectionsSupported &&
          <MarkWarning
@@ -255,4 +56,4 @@ function Performance ({ className = '', favorites, sessionEra, toggleFavorite }:
   );
 }
 
-export default React.memo(Performance);
+export default Performance;

--- a/packages/page-staking/src/Performance/Summary.tsx
+++ b/packages/page-staking/src/Performance/Summary.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, {useMemo} from 'react';
 import styled from 'styled-components';
 
 import SummarySession from '@polkadot/app-staking/Performance/SummarySession';
@@ -9,31 +9,33 @@ import { CardSummary, Spinner, SummaryBox } from '@polkadot/react-components';
 import { formatNumber } from '@polkadot/util';
 
 import { useTranslation } from '../translate';
-import { ValidatorPerformance } from './Performance';
+import {EraValidatorPerformance} from "@polkadot/app-staking/Performance/Performance";
 
 interface Props {
   className?: string;
-  validatorPerformances: ValidatorPerformance[];
+  eraValidatorPerformances: EraValidatorPerformance[];
   era: number;
   session: number;
 }
 
-function Summary ({ className = '', era, session, validatorPerformances }: Props): React.ReactElement<Props> {
+function Summary ({ className = '', era, session, eraValidatorPerformances }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
-
-  const committeeLength = validatorPerformances.filter((performance) => performance.isCommittee).length;
+  const committeeLength = useMemo(() => {
+    return eraValidatorPerformances.filter((perf) => perf.isCommittee).length;
+    }, [eraValidatorPerformances]
+  );
 
   return (
     <SummaryBox className={className}>
       <section>
         <CardSummary label={t<string>('era validators')}>
-          {validatorPerformances.length
-            ? <>{formatNumber(validatorPerformances.length)}</>
+          {eraValidatorPerformances.length
+            ? <>{formatNumber(eraValidatorPerformances.length)}</>
             : <Spinner noLabel />
           }
         </CardSummary>
         <CardSummary label={t<string>('committee size')}>
-          {committeeLength > 0
+          {committeeLength
             ? <>{formatNumber(committeeLength)}</>
             : <Spinner noLabel />
           }

--- a/packages/page-staking/src/Performance/Summary.tsx
+++ b/packages/page-staking/src/Performance/Summary.tsx
@@ -1,15 +1,15 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, {useMemo} from 'react';
+import React, { useMemo } from 'react';
 import styled from 'styled-components';
 
+import { EraValidatorPerformance } from '@polkadot/app-staking/Performance/Performance';
 import SummarySession from '@polkadot/app-staking/Performance/SummarySession';
 import { CardSummary, Spinner, SummaryBox } from '@polkadot/react-components';
 import { formatNumber } from '@polkadot/util';
 
 import { useTranslation } from '../translate';
-import {EraValidatorPerformance} from "@polkadot/app-staking/Performance/Performance";
 
 interface Props {
   className?: string;
@@ -18,11 +18,11 @@ interface Props {
   session: number;
 }
 
-function Summary ({ className = '', era, session, eraValidatorPerformances }: Props): React.ReactElement<Props> {
+function Summary ({ className = '', era, eraValidatorPerformances, session }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const committeeLength = useMemo(() => {
     return eraValidatorPerformances.filter((perf) => perf.isCommittee).length;
-    }, [eraValidatorPerformances]
+  }, [eraValidatorPerformances]
   );
 
   return (

--- a/packages/page-staking/src/Performance/index.tsx
+++ b/packages/page-staking/src/Performance/index.tsx
@@ -3,12 +3,13 @@
 
 import React, { useCallback, useMemo, useState } from 'react';
 
+import Performance from '@polkadot/app-staking/Performance/Performance';
+import useCurrentSessionInfo from '@polkadot/app-staking/Performance/useCurrentSessionInfo';
 import { useTranslation } from '@polkadot/app-staking/translate';
-import {Button, Input, MarkWarning, Spinner} from '@polkadot/react-components';
-import {useApi} from '@polkadot/react-hooks';
-import Performance from "@polkadot/app-staking/Performance/Performance";
+import { Button, Input, MarkWarning, Spinner } from '@polkadot/react-components';
+import { useApi } from '@polkadot/react-hooks';
+
 import useEra from './useEra';
-import useCurrentSessionInfo from "@polkadot/app-staking/Performance/useCurrentSessionInfo";
 
 export interface SessionEra {
   session: number,
@@ -28,14 +29,15 @@ function PerformancePage (): React.ReactElement {
 
   const sessionEra = useMemo((): SessionEra | undefined => {
     if (era && inputSession) {
-      return {currentSessionMode: false, era: era, session: inputSession};
+      return { currentSessionMode: false, era, session: inputSession };
     }
+
     if (currentSession && currentEra) {
-      return {currentSessionMode: true, era: currentEra, session: currentSession};
+      return { currentSessionMode: true, era: currentEra, session: currentSession };
     }
+
     return undefined;
   }, [inputSession, currentEra, currentSession, era]);
-
 
   const _onChangeKey = useCallback(
     (key: string): void => {
@@ -83,7 +85,6 @@ function PerformancePage (): React.ReactElement {
   [t, currentSession, minimumSessionNumber]
   );
 
-
   if (!api.runtimeChain.toString().includes('Aleph Zero')) {
     return (
       <MarkWarning content={'Unsupported chain.'} />
@@ -98,9 +99,9 @@ function PerformancePage (): React.ReactElement {
 
   return (
     <>
-       <section className='performance--actionrow'>
-         <div className='performance--actionrow-value'>
-           <Input
+      <section className='performance--actionrow'>
+        <div className='performance--actionrow-value'>
+          <Input
             autoFocus
             help={help}
             isError={!parsedSessionNumber}
@@ -109,22 +110,21 @@ function PerformancePage (): React.ReactElement {
             onEnter={_onAdd}
           />
         </div>
-         <div className='performance--actionrow-buttons'>
-           <Button
-             icon='play'
-             isDisabled={!parsedSessionNumber}
-             onClick={_onAdd}
-           />
-         </div>
-         </section>
-         <section>
-         <Performance
-           sessionEra={sessionEra}
-         />
-       </section>
+        <div className='performance--actionrow-buttons'>
+          <Button
+            icon='play'
+            isDisabled={!parsedSessionNumber}
+            onClick={_onAdd}
+          />
+        </div>
+      </section>
+      <section>
+        <Performance
+          sessionEra={sessionEra}
+        />
+      </section>
     </>
   );
 }
 
 export default React.memo(PerformancePage);
-

--- a/packages/page-staking/src/Performance/index.tsx
+++ b/packages/page-staking/src/Performance/index.tsx
@@ -10,18 +10,13 @@ import Performance from "@polkadot/app-staking/Performance/Performance";
 import useEra from './useEra';
 import useCurrentSessionInfo from "@polkadot/app-staking/Performance/useCurrentSessionInfo";
 
-interface Props {
-  favorites: string[];
-  toggleFavorite: (address: string) => void;
-}
-
 export interface SessionEra {
   session: number,
   era: number,
   currentSessionMode: boolean,
 }
 
-function PerformancePage ({ favorites, toggleFavorite }: Props): React.ReactElement<Props> {
+function PerformancePage (): React.ReactElement {
   const { t } = useTranslation();
   const { api } = useApi();
 
@@ -124,9 +119,7 @@ function PerformancePage ({ favorites, toggleFavorite }: Props): React.ReactElem
          </section>
          <section>
          <Performance
-           favorites={favorites}
            sessionEra={sessionEra}
-           toggleFavorite={toggleFavorite}
          />
        </section>
     </>

--- a/packages/page-staking/src/Performance/useCommitteePerformance.tsx
+++ b/packages/page-staking/src/Performance/useCommitteePerformance.tsx
@@ -54,7 +54,6 @@ function useSessionCommitteePerformanceImpl (sessions: number[]): SessionCommitt
   const MINIMUM_SUPPORTED_ELECTIONS_PALLET_VERSION = 3;
 
   useEffect(() => {
-    console.log('sessions in hook', sessions);
     const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
     const firstBlocksInSession = sessions.map((session) => session * sessionPeriod);
 
@@ -238,12 +237,6 @@ function useSessionCommitteePerformanceImpl (sessions: number[]): SessionCommitt
       const firstSessionBlockAuthor = firstSessionBlockAuthors[index];
 
       if (committee && expectedValidatorBlockCountLookup && firstSessionBlockAuthor) {
-        console.log('sessionId', session);
-        console.log('sessionValidatorBlockCountLookup', sessionValidatorBlockCountLookup);
-        console.log('expectedValidatorBlockCountLookup', expectedValidatorBlockCountLookup);
-        console.log('isPalletElectionsSupported', isPalletElectionsSupported);
-        console.log('firstSessionBlockAuthor', firstSessionBlockAuthor);
-        console.log('committee', committee);
 
         const validatorPerformances = committee.map((validator) => getValidatorPerformance(validator,
           sessionValidatorBlockCountLookup,

--- a/packages/page-staking/src/Performance/useCommitteePerformance.tsx
+++ b/packages/page-staking/src/Performance/useCommitteePerformance.tsx
@@ -54,21 +54,23 @@ function useSessionCommitteePerformanceImpl (sessions: number[]): SessionCommitt
   const MINIMUM_SUPPORTED_ELECTIONS_PALLET_VERSION = 3;
 
   useEffect(() => {
-    const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
-    const firstBlocksInSession = sessions.map((session) => session * sessionPeriod);
+    if (api && api.consts.elections) {
+      const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
+      const firstBlocksInSession = sessions.map((session) => session * sessionPeriod);
 
-    firstBlocksInSession.forEach((firstBlockInSession, index) => {
-      api.rpc.chain
-        .getBlockHash(firstBlockInSession)
-        .then((result): void => {
-          setFirstBlockInSessionHashes((existingItems) => {
-            return existingItems.map((item, j) => {
-              return j === index ? result : item;
+      firstBlocksInSession.forEach((firstBlockInSession, index) => {
+        api.rpc.chain
+          .getBlockHash(firstBlockInSession)
+          .then((result): void => {
+            setFirstBlockInSessionHashes((existingItems) => {
+              return existingItems.map((item, j) => {
+                return j === index ? result : item;
+              });
             });
-          });
-        })
-        .catch(console.error);
-    });
+          })
+          .catch(console.error);
+      });
+    }
   },
   // eslint-disable-next-line react-hooks/exhaustive-deps
   [api, JSON.stringify(sessions)]
@@ -94,22 +96,24 @@ function useSessionCommitteePerformanceImpl (sessions: number[]): SessionCommitt
   );
 
   useEffect(() => {
-    const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
-    const lastBlocksInSession = sessions.map((session) => (session + 1) * sessionPeriod - 1);
+    if (api && api.consts.elections) {
+      const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
+      const lastBlocksInSession = sessions.map((session) => (session + 1) * sessionPeriod - 1);
 
-    lastBlocksInSession.forEach((lastBlockInSession, index) => {
-      api.rpc.chain
-        .getBlockHash(lastBlockInSession)
-        .then((maybeHash): void => {
-          maybeHash && !maybeHash.isEmpty &&
-          setLastBlockInSessionsHashes((existingItems) => {
-            return existingItems.map((item, j) => {
-              return j === index ? maybeHash : item;
+      lastBlocksInSession.forEach((lastBlockInSession, index) => {
+        api.rpc.chain
+          .getBlockHash(lastBlockInSession)
+          .then((maybeHash): void => {
+            maybeHash && !maybeHash.isEmpty &&
+            setLastBlockInSessionsHashes((existingItems) => {
+              return existingItems.map((item, j) => {
+                return j === index ? maybeHash : item;
+              });
             });
-          });
-        })
-        .catch(console.error);
-    });
+          })
+          .catch(console.error);
+      });
+    }
   },
   // eslint-disable-next-line react-hooks/exhaustive-deps
   [api, JSON.stringify(sessions)]
@@ -237,7 +241,6 @@ function useSessionCommitteePerformanceImpl (sessions: number[]): SessionCommitt
       const firstSessionBlockAuthor = firstSessionBlockAuthors[index];
 
       if (committee && expectedValidatorBlockCountLookup && firstSessionBlockAuthor) {
-
         const validatorPerformances = committee.map((validator) => getValidatorPerformance(validator,
           sessionValidatorBlockCountLookup,
           expectedValidatorBlockCountLookup));

--- a/packages/page-staking/src/Performance/useCurrentSessionInfo.tsx
+++ b/packages/page-staking/src/Performance/useCurrentSessionInfo.tsx
@@ -1,39 +1,38 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {useMemo} from 'react';
+import { useMemo } from 'react';
 
-import {createNamedHook, useApi, useCall} from '@polkadot/react-hooks';
-import {DeriveSessionProgress} from "@polkadot/api-derive/types";
+import { DeriveSessionProgress } from '@polkadot/api-derive/types';
+import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 
-function useCurrentSessionInfoImpl() {
-  const {api} = useApi();
+function useCurrentSessionInfoImpl () {
+  const { api } = useApi();
 
   const sessionInfo = useCall<DeriveSessionProgress>(api.derive.session.progress);
   const currentSession = useMemo(() => {
-      return sessionInfo?.currentIndex.toNumber();
-    },
-    [sessionInfo]
+    return sessionInfo?.currentIndex.toNumber();
+  },
+  [sessionInfo]
   );
 
   const currentEra = useMemo(() => {
-      return sessionInfo?.currentEra.toNumber();
-    },
-    [sessionInfo]
+    return sessionInfo?.currentEra.toNumber();
+  },
+  [sessionInfo]
   );
   const historyDepth = useCall<number>(api.query.staking.historyDepth);
   const minimumSessionNumber = useMemo(() => {
-      if (currentSession && historyDepth && sessionInfo) {
-        return Math.max(currentSession - historyDepth * sessionInfo.sessionsPerEra.toNumber(), 1);
-      }
+    if (currentSession && historyDepth && sessionInfo) {
+      return Math.max(currentSession - historyDepth * sessionInfo.sessionsPerEra.toNumber(), 1);
+    }
 
-      return undefined;
-    },
-    [historyDepth, currentSession, sessionInfo]
+    return undefined;
+  },
+  [historyDepth, currentSession, sessionInfo]
   );
 
   return [currentSession, currentEra, historyDepth, minimumSessionNumber];
 }
 
 export default createNamedHook('useCurrentSessionInfo', useCurrentSessionInfoImpl);
-

--- a/packages/page-staking/src/Performance/useCurrentSessionInfo.tsx
+++ b/packages/page-staking/src/Performance/useCurrentSessionInfo.tsx
@@ -1,0 +1,39 @@
+// Copyright 2017-2022 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import {useMemo} from 'react';
+
+import {createNamedHook, useApi, useCall} from '@polkadot/react-hooks';
+import {DeriveSessionProgress} from "@polkadot/api-derive/types";
+
+function useCurrentSessionInfoImpl() {
+  const {api} = useApi();
+
+  const sessionInfo = useCall<DeriveSessionProgress>(api.derive.session.progress);
+  const currentSession = useMemo(() => {
+      return sessionInfo?.currentIndex.toNumber();
+    },
+    [sessionInfo]
+  );
+
+  const currentEra = useMemo(() => {
+      return sessionInfo?.currentEra.toNumber();
+    },
+    [sessionInfo]
+  );
+  const historyDepth = useCall<number>(api.query.staking.historyDepth);
+  const minimumSessionNumber = useMemo(() => {
+      if (currentSession && historyDepth && sessionInfo) {
+        return Math.max(currentSession - historyDepth * sessionInfo.sessionsPerEra.toNumber(), 1);
+      }
+
+      return undefined;
+    },
+    [historyDepth, currentSession, sessionInfo]
+  );
+
+  return [currentSession, currentEra, historyDepth, minimumSessionNumber];
+}
+
+export default createNamedHook('useCurrentSessionInfo', useCurrentSessionInfoImpl);
+

--- a/packages/page-staking/src/Performance/useEra.tsx
+++ b/packages/page-staking/src/Performance/useEra.tsx
@@ -1,0 +1,54 @@
+// Copyright 2017-2022 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from 'react';
+
+import {createNamedHook, useApi, useCall} from '@polkadot/react-hooks';
+import { EraIndex } from '@polkadot/types/interfaces';
+import { Option, u32 } from '@polkadot/types-codec';
+
+type SessionIndexEntry = [{ args: [EraIndex] }, Option<u32>];
+
+function useEraImpl(inputSession?: number) {
+  const { api } = useApi();
+  const erasStartSessionIndex = useCall<SessionIndexEntry[]>(api.query.staking.erasStartSessionIndex.entries);
+
+  function calculateEra (session: number, erasStartSessionIndex: SessionIndexEntry[]) {
+    const erasStartSessionIndexLookup: [number, number][] = [];
+
+    erasStartSessionIndex.filter(([, values]) => values.isSome)
+      .forEach(([key, values]) => {
+        const eraIndex = key.args[0];
+
+        erasStartSessionIndexLookup.push([eraIndex.toNumber(), values.unwrap().toNumber()]);
+      });
+    erasStartSessionIndexLookup.sort(([eraIndexA], [eraIndexB]) => {
+      return eraIndexA - eraIndexB;
+    });
+
+    for (let i = 0; i < erasStartSessionIndexLookup.length; i++) {
+      const eraIndex = erasStartSessionIndexLookup[i][0];
+      const currentEraSessionStart = erasStartSessionIndexLookup[i][1];
+      const currentEraSessionEnd = i + 1 < erasStartSessionIndexLookup.length ? erasStartSessionIndexLookup[i + 1][1] - 1 : undefined;
+
+      if (currentEraSessionStart <= session && currentEraSessionEnd && session <= currentEraSessionEnd) {
+        return eraIndex;
+      }
+    }
+
+    const lastErasStartSessionIndexLookup = erasStartSessionIndexLookup.length - 1;
+
+    return erasStartSessionIndexLookup[lastErasStartSessionIndexLookup][0];
+  }
+
+  const era = useMemo((): number | undefined => {
+    if (inputSession && erasStartSessionIndex) {
+      return calculateEra(inputSession, erasStartSessionIndex);
+    }
+    return undefined;
+  }, [inputSession, erasStartSessionIndex]);
+
+  return era;
+}
+
+export default createNamedHook('useEra', useEraImpl);

--- a/packages/page-staking/src/Performance/useEra.tsx
+++ b/packages/page-staking/src/Performance/useEra.tsx
@@ -3,13 +3,13 @@
 
 import { useMemo } from 'react';
 
-import {createNamedHook, useApi, useCall} from '@polkadot/react-hooks';
+import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 import { EraIndex } from '@polkadot/types/interfaces';
 import { Option, u32 } from '@polkadot/types-codec';
 
 type SessionIndexEntry = [{ args: [EraIndex] }, Option<u32>];
 
-function useEraImpl(inputSession?: number) {
+function useEraImpl (inputSession?: number) {
   const { api } = useApi();
   const erasStartSessionIndex = useCall<SessionIndexEntry[]>(api.query.staking.erasStartSessionIndex.entries);
 
@@ -45,6 +45,7 @@ function useEraImpl(inputSession?: number) {
     if (inputSession && erasStartSessionIndex) {
       return calculateEra(inputSession, erasStartSessionIndex);
     }
+
     return undefined;
   }, [inputSession, erasStartSessionIndex]);
 

--- a/packages/page-staking/src/Performance/useValidatorPerformance.tsx
+++ b/packages/page-staking/src/Performance/useValidatorPerformance.tsx
@@ -1,0 +1,228 @@
+// Copyright 2017-2022 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { DeriveEraExposure } from '@polkadot/api-derive/types';
+import {createNamedHook, useApi, useCall} from '@polkadot/react-hooks';
+import { StorageKey } from '@polkadot/types';
+import { Hash } from '@polkadot/types/interfaces';
+import { AnyTuple, Codec } from '@polkadot/types/types';
+
+import { SessionEra } from './index';
+
+interface Props {
+  favorites: string[];
+  sessionEra: SessionEra,
+}
+
+export interface ValidatorPerformance {
+  accountId: string,
+  blockCount: number,
+  expectedBlockCount: number,
+  isCommittee: boolean;
+  isFavourite: boolean,
+}
+
+function useValidatorPerformanceImpl ({ favorites, sessionEra }: Props): [ValidatorPerformance[], string[], undefined | boolean]{
+  const { api } = useApi();
+
+  const [validatorPerformances, setValidatorPerformances] = useState<ValidatorPerformance[]>([]);
+  const [committee, setCommittee] = useState<string[]>([]);
+
+  const [firstBlockInSessionHash, setFirstBlockInSessionHash] = useState<Hash | undefined>(undefined);
+  const [lastBlockInSessionHash, setLastBlockInSessionHash] = useState<Hash | undefined>(undefined);
+  const [firstSessionBlockAuthor, setFirstSessionBlockAuthor] = useState<string | undefined>(undefined);
+  const [isPalletElectionsSupported, setIsPalletElectionsSupported] = useState<boolean | undefined>(undefined);
+
+  const [sessionValidatorBlockCountLookup, setSessionValidatorBlockCountLookup] = useState<[string, number][]>([]);
+
+  const MINIMUM_SUPPORTED_ELECTIONS_PALLET_VERSION = 3;
+
+  const eraExposure = useCall<DeriveEraExposure>(api.derive.staking.eraExposure, [sessionEra.era]);
+
+  const eraValidators = useMemo(() => {
+    if (eraExposure?.validators) {
+      return Object.keys(eraExposure?.validators);
+    }
+
+    return [];
+  }, [eraExposure]
+  );
+
+  useEffect(() => {
+    const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
+    const firstBlockInSession = sessionEra.session * sessionPeriod;
+
+    api.rpc.chain
+      .getBlockHash(firstBlockInSession)
+      .then((result): void => {
+        setFirstBlockInSessionHash(result);
+      })
+      .catch(console.error);
+  },
+  [api, sessionEra]
+  );
+
+  useEffect(() => {
+    if (firstBlockInSessionHash) {
+      api.at(firstBlockInSessionHash.toString()).then((result) => {
+        result.query.elections.palletVersion().then((version) => {
+          setIsPalletElectionsSupported(Number(version.toString()) >= MINIMUM_SUPPORTED_ELECTIONS_PALLET_VERSION);
+        }).catch(console.error);
+      }).catch(console.error);
+    }
+  }, [api, firstBlockInSessionHash]);
+
+  useEffect(() => {
+    if (!sessionEra.currentSessionMode) {
+      const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
+      const lastBlockInSession = (sessionEra.session + 1) * sessionPeriod - 1;
+
+      api.rpc.chain
+        .getBlockHash(lastBlockInSession)
+        .then((result): void => {
+          setLastBlockInSessionHash(result);
+        })
+        .catch(console.error);
+    }
+  },
+  [api, sessionEra]
+  );
+
+  useEffect(() => {
+    if (firstBlockInSessionHash) {
+      api.derive.chain.getHeader(firstBlockInSessionHash).then((header) => {
+        if (header && !header.isEmpty && header.author) {
+          setFirstSessionBlockAuthor(header.author.toString());
+        }
+      }).catch(console.error);
+    }
+  },
+  [api, firstBlockInSessionHash]
+  );
+
+  function parseSessionBlockCount (sessionValidatorBlockCountValue: [StorageKey<AnyTuple>, Codec][], firstSessionBlockAuthor: string): [string, number][] {
+    return sessionValidatorBlockCountValue.map(([key, values]) => {
+      const account = key.args[0].toString();
+      let count = Number(values.toString());
+
+      if (account === firstSessionBlockAuthor) {
+        // a workaround for the fact that the first session block author is not reflected in that block
+        // elections.sessionValidatorBlockCount state
+        count += 1;
+      }
+
+      return [account, count];
+    });
+  }
+
+  useEffect(() => {
+    if (lastBlockInSessionHash && firstSessionBlockAuthor) {
+      api.at(lastBlockInSessionHash.toString()).then((result) => {
+        const sessionValidatorBlockCount = result.query.elections.sessionValidatorBlockCount;
+
+        sessionValidatorBlockCount && sessionValidatorBlockCount.entries().then((value) => {
+          setSessionValidatorBlockCountLookup(parseSessionBlockCount(value, firstSessionBlockAuthor));
+        }).catch(console.error);
+      }).catch(console.error);
+    }
+  }
+  , [api, lastBlockInSessionHash, firstSessionBlockAuthor]
+  );
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (sessionEra.currentSessionMode && firstSessionBlockAuthor) {
+        api && api.query.elections && api.query.elections.sessionValidatorBlockCount &&
+        api.query.elections.sessionValidatorBlockCount.entries().then((value) => {
+          setSessionValidatorBlockCountLookup(parseSessionBlockCount(value, firstSessionBlockAuthor));
+        }
+        ).catch(console.error);
+      }
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [firstSessionBlockAuthor, sessionEra, api]);
+
+  useEffect(() => {
+    if (firstBlockInSessionHash) {
+      api.at(firstBlockInSessionHash.toString()).then((resultApi) => {
+        const validators = resultApi.query.session.validators;
+
+        validators && validators().then((value) => {
+          setCommittee(value.map((validator) => validator.toString()));
+        }).catch(console.error);
+      }).catch(console.error);
+    }
+  }, [api, firstBlockInSessionHash]
+  );
+
+  const expectedSessionValidatorBlockCount = useMemo(() => {
+    const result: [string, number][] = [];
+
+    // should not change at all during runtime, therefore it's fine to use current api object
+    const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
+
+    const index = committee.findIndex((value) => value.toString() === firstSessionBlockAuthor);
+
+    if (index === -1) {
+      return [];
+    }
+
+    for (let i = 0; i < committee.length; i++) {
+      const author = committee[(i + index) % committee.length];
+      const offset = Math.max(sessionPeriod - i, 0);
+
+      result.push([author.toString(), Math.ceil(offset / committee.length)]);
+    }
+
+    return result;
+  },
+  [api, firstSessionBlockAuthor, committee]
+  );
+
+  function getValidatorPerformance (validator: string,
+    sessionValidatorBlockCountLookup: [string, number][],
+    expectedSessionValidatorBlockCount: [string, number][],
+    favorites: string[],
+    isCommittee: boolean): ValidatorPerformance {
+    const maybeCount = sessionValidatorBlockCountLookup.find(([id]) => id === validator);
+    const count = maybeCount ? maybeCount[1] : 0;
+    const maybeExpectedBlockCount = expectedSessionValidatorBlockCount.find(([id]) => id === validator);
+    const expectedBlockCount = maybeExpectedBlockCount ? maybeExpectedBlockCount[1] : 0;
+    const isFavourite = !!favorites.find((value) => validator === value);
+
+    return {
+      accountId: validator,
+      blockCount: count,
+      expectedBlockCount,
+      isCommittee,
+      isFavourite
+    };
+  }
+
+  useEffect(() => {
+    const nonCommittee = eraValidators.filter((validator) => !committee.find((value) => validator === value));
+
+    const nonCommitteePerformances = nonCommittee.map((validator) => getValidatorPerformance(validator,
+      sessionValidatorBlockCountLookup,
+      expectedSessionValidatorBlockCount,
+      favorites,
+      false));
+    const committeePerformances = committee.map((validator) => getValidatorPerformance(validator,
+      sessionValidatorBlockCountLookup,
+      expectedSessionValidatorBlockCount,
+      favorites,
+      true));
+
+    setValidatorPerformances(committeePerformances.concat(nonCommitteePerformances));
+  },
+  [committee, eraValidators, sessionValidatorBlockCountLookup, expectedSessionValidatorBlockCount, favorites]
+
+  );
+
+  return [validatorPerformances, committee, isPalletElectionsSupported];
+}
+
+export default createNamedHook('useValidatorPerformance', useValidatorPerformanceImpl);

--- a/packages/page-staking/src/Query/index.tsx
+++ b/packages/page-staking/src/Query/index.tsx
@@ -1,13 +1,17 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useCallback, useState } from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import { useParams } from 'react-router-dom';
 
 import { Button, InputAddressSimple } from '@polkadot/react-components';
 
 import { useTranslation } from '../translate';
 import Validator from './Validator';
+import useCurrentSessionInfo from "@polkadot/app-staking/Performance/useCurrentSessionInfo";
+import useValidatorPerformance, { ValidatorPerformance } from "@polkadot/app-staking/Performance/useValidatorPerformance";
+import useEra from "@polkadot/app-staking/Performance/useEra";
+
 
 interface Props {
   className?: string;
@@ -18,6 +22,22 @@ function Query ({ className }: Props): React.ReactElement<Props> {
   const { value } = useParams<{ value: string }>();
   const [validatorId, setValidatorId] = useState<string | null>(value || null);
 
+  const [currentSession, currentEra, historyDepth, minimumSessionNumber] = useCurrentSessionInfo();
+  const [ sessionsValidatorPerformance, setSessionsValidatorPerformance ] = useState<ValidatorPerformance[]>([]);
+
+  function range(size : number, startAt = 0) {
+    return [...Array(size).keys()].map(i => i + startAt);
+  }
+
+  const pastSessions = useMemo(() => {
+      if (currentSession && currentEra) {
+        const sessionQueryDepth = 10;
+        return range(sessionQueryDepth, currentSession - sessionQueryDepth - 1);
+      }
+      return [];
+    }, [currentSession, currentEra]
+  );
+  
   const _onQuery = useCallback(
     (): void => {
       if (validatorId) {

--- a/packages/page-staking/src/Query/index.tsx
+++ b/packages/page-staking/src/Query/index.tsx
@@ -9,7 +9,7 @@ import { calculatePercentReward } from '@polkadot/app-staking/Performance/Curren
 import useSessionCommitteePerformance, { ValidatorPerformance } from '@polkadot/app-staking/Performance/useCommitteePerformance';
 import useCurrentSessionInfo from '@polkadot/app-staking/Performance/useCurrentSessionInfo';
 import { Button, InputAddressSimple, Table } from '@polkadot/react-components';
-import {useApi, useLoadingDelay} from '@polkadot/react-hooks';
+import { useApi, useLoadingDelay } from '@polkadot/react-hooks';
 
 import { useTranslation } from '../translate';
 import Validator from './Validator';
@@ -33,7 +33,7 @@ function Query ({ className }: Props): React.ReactElement<Props> {
 
   const isAlephChain = useMemo(() => {
     return api.runtimeChain.toString().includes('Aleph Zero');
-    }, [api]
+  }, [api]
   );
 
   const pastSessions = useMemo(() => {
@@ -52,11 +52,12 @@ function Query ({ className }: Props): React.ReactElement<Props> {
   const sessionCommitteePerformance = useSessionCommitteePerformance(pastSessions);
 
   const filteredSessionPerformances = useMemo(() => {
-    return sessionCommitteePerformance.map(({ performance, sessionId , isPalletElectionsSupported}) => {
-      return !!isPalletElectionsSupported ?
-        performance.filter((performance) => performance.accountId === value).map((performance) => {
+    return sessionCommitteePerformance.map(({ isPalletElectionsSupported, performance, sessionId }) => {
+      return isPalletElectionsSupported
+        ? performance.filter((performance) => performance.accountId === value).map((performance) => {
           return [performance, sessionId, value];
-        }) : [];
+        })
+        : [];
     }).flat();
   },
   [sessionCommitteePerformance, value]);

--- a/packages/page-staking/src/Query/index.tsx
+++ b/packages/page-staking/src/Query/index.tsx
@@ -9,7 +9,7 @@ import { Button, InputAddressSimple } from '@polkadot/react-components';
 import { useTranslation } from '../translate';
 import Validator from './Validator';
 import useCurrentSessionInfo from "@polkadot/app-staking/Performance/useCurrentSessionInfo";
-import useValidatorPerformance, { ValidatorPerformance } from "@polkadot/app-staking/Performance/useValidatorPerformance";
+import useValidatorPerformance, { ValidatorPerformance } from "@polkadot/app-staking/Performance/useCommitteePerformance";
 import useEra from "@polkadot/app-staking/Performance/useEra";
 
 

--- a/packages/page-staking/src/Query/index.tsx
+++ b/packages/page-staking/src/Query/index.tsx
@@ -37,7 +37,7 @@ function Query ({ className }: Props): React.ReactElement<Props> {
       return [];
     }, [currentSession, currentEra]
   );
-  
+
   const _onQuery = useCallback(
     (): void => {
       if (validatorId) {

--- a/packages/page-staking/src/Query/index.tsx
+++ b/packages/page-staking/src/Query/index.tsx
@@ -36,8 +36,6 @@ function Query ({ className }: Props): React.ReactElement<Props> {
       const minSessionNumber = Math.max(minimumSessionNumber, currentSession - maxSessionQueryDepth);
       const queryDepth = currentSession - minSessionNumber;
 
-      console.log(queryDepth);
-
       return range(queryDepth, currentSession - queryDepth);
     }
 
@@ -86,8 +84,6 @@ function Query ({ className }: Props): React.ReactElement<Props> {
       [t('max % reward'), 'expand']
     ]
   );
-
-  console.log('list', list);
 
   return (
     <div className={className}>

--- a/packages/page-staking/src/Targets/Validator.tsx
+++ b/packages/page-staking/src/Targets/Validator.tsx
@@ -29,7 +29,7 @@ interface Props {
   toggleSelected: (accountId: string) => void;
 }
 
-function queryAddress (address: string): void {
+export function queryAddress (address: string): void {
   window.location.hash = `/staking/query/${address}`;
 }
 

--- a/packages/page-staking/src/index.tsx
+++ b/packages/page-staking/src/index.tsx
@@ -257,6 +257,35 @@ export default React.memo(styled(StakingApp)(({ theme }: ThemeProps) => `
     }
   }
 
+ .performance--actionrow {
+    align-items: flex-start;
+    display: flex;
+
+    .ui--Button {
+      margin: 0.25rem;
+    }
+
+    &.head {
+      flex: 1 1 100%;
+      margin: 0 auto;
+      max-width: 620px;
+    }
+  }
+
+  .performance--actionrow-value {
+    flex: 1;
+    min-width: 0;
+
+    .ui--output {
+      word-break: break-all;
+    }
+  }
+
+  .performance--actionrow-buttons {
+    flex: 0;
+    padding: 0.5rem 0.25rem;
+  }
+
   .ui--Expander.stakeOver {
     .ui--Expander-summary {
       color: var(--color-error);

--- a/packages/page-staking/src/index.tsx
+++ b/packages/page-staking/src/index.tsx
@@ -200,10 +200,7 @@ function StakingApp ({ basePath, className = '' }: Props): React.ReactElement<Pr
           />
         </Route>
         <Route path={pathRef.current.performance}>
-          <PerformancePage
-            favorites={favorites}
-            toggleFavorite={toggleFavorite}
-          />
+          <PerformancePage/>
         </Route>
       </Switch>
       <Actions

--- a/packages/page-staking/src/index.tsx
+++ b/packages/page-staking/src/index.tsx
@@ -200,7 +200,7 @@ function StakingApp ({ basePath, className = '' }: Props): React.ReactElement<Pr
           />
         </Route>
         <Route path={pathRef.current.performance}>
-          <PerformancePage/>
+          <PerformancePage />
         </Route>
       </Switch>
       <Actions


### PR DESCRIPTION
This PR introduces a significant refactor of the previous feature (Staking/Performance page) so it is possible to reuse code as a custom React hook that queries actual and expected block count in the past sessions.  Due to technical limitations of React (actually, this is an assumption of this framework) I was not able to parametrize `useCommmiteePerformance` by a single session id and then call it via a loop, instead, I needed to make the hook accept an array of sessions Ids. Nevertheless, PR is done and tested on the local chain/Testnet/Mainnet AlephNode. 