### PR TITLE
A0-1384 Fix for order of calling react hooks.

### DIFF
--- a/packages/page-staking/src/Performance/Address/index.tsx
+++ b/packages/page-staking/src/Performance/Address/index.tsx
@@ -36,15 +36,14 @@ function Address ({ address, blocksCreated, blocksTarget, filterName, rewardPerc
     [api, accountInfo, address, filterName]
   );
 
-  if (!isVisible) {
-    return null;
-  }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const onQueryStats = useCallback(
     () => queryAddress(address),
     [address]
   );
+
+  if (!isVisible) {
+    return null;
+  }
 
   return (
     <tr>


### PR DESCRIPTION
React hooks must be called always in the same order when page renders. When recent features were introduced, a bug chimed in and this rule has been broken. Not in the [original code](https://github.com/Cardinal-Cryptography/apps/blob/alephzero/packages/page-staking/src/Validators/Address/index.tsx#L114-L116) the early return is located after all the hooks, so does now in the fixed version.