### PR TITLE
A0 1480 frontend changes for kicks

### DIFF
--- a/packages/page-bounties/src/Bounty.tsx
+++ b/packages/page-bounties/src/Bounty.tsx
@@ -153,7 +153,7 @@ function Bounty ({ bestNumber, bounty, className = '', description, index, propo
             <div className='inline-balance'><FormatBalance value={bond} /></div>
           </div>
           {curator && (
-            <div className='label-column-right'>
+            <div className='`label-column-right`'>
               <div className='label'>{t("Curator's fee")}</div>
               <div className='inline-balance'>{<FormatBalance value={fee} />}</div>
             </div>

--- a/packages/page-bounties/src/Bounty.tsx
+++ b/packages/page-bounties/src/Bounty.tsx
@@ -153,7 +153,7 @@ function Bounty ({ bestNumber, bounty, className = '', description, index, propo
             <div className='inline-balance'><FormatBalance value={bond} /></div>
           </div>
           {curator && (
-            <div className='`label-column-right`'>
+            <div className='label-column-right'>
               <div className='label'>{t("Curator's fee")}</div>
               <div className='inline-balance'>{<FormatBalance value={fee} />}</div>
             </div>

--- a/packages/page-staking/src/Kickouts/Address/index.tsx
+++ b/packages/page-staking/src/Kickouts/Address/index.tsx
@@ -1,0 +1,68 @@
+// Copyright 2017-2022 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useCallback, useMemo } from 'react';
+
+import { ApiPromise } from '@polkadot/api';
+import { AddressSmall, Icon } from '@polkadot/react-components';
+import { checkVisibility } from '@polkadot/react-components/util';
+import { useApi, useDeriveAccountInfo } from '@polkadot/react-hooks';
+
+interface Props {
+  address: string;
+  era: number;
+  kickoutReason: string;
+  filterName: string,
+}
+
+function useAddressCalls (api: ApiPromise, address: string) {
+  const accountInfo = useDeriveAccountInfo(address);
+
+  return { accountInfo };
+}
+
+function queryAddress (address: string) {
+  window.location.hash = `/staking/query/${address}`;
+}
+
+function Address ({ address, era, filterName, kickoutReason }: Props): React.ReactElement<Props> | null {
+  const { api } = useApi();
+  const { accountInfo } = useAddressCalls(api, address);
+
+  const onQueryStats = useCallback(
+    () => queryAddress(address),
+    [address]
+  );
+
+  const isVisible = useMemo(
+    () => accountInfo ? checkVisibility(api, address, accountInfo, filterName) : true,
+    [api, accountInfo, address, filterName]
+  );
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <tr>
+      <td className='address'>
+        <AddressSmall value={address} />
+      </td>
+      <td className='number'>
+        {era}
+      </td>
+      <td className='number'>
+        {kickoutReason}
+      </td>
+      <td className='number'>
+        <Icon
+          className='staking--stats highlight--color'
+          icon='chart-line'
+          onClick={onQueryStats}
+        />
+      </td>
+    </tr>
+  );
+}
+
+export default React.memo(Address);

--- a/packages/page-staking/src/Kickouts/CurrentList.tsx
+++ b/packages/page-staking/src/Kickouts/CurrentList.tsx
@@ -1,0 +1,75 @@
+// Copyright 2017-2022 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useMemo, useRef, useState } from 'react';
+
+import { Table } from '@polkadot/react-components';
+import { useLoadingDelay } from '@polkadot/react-hooks';
+
+import Filtering from '../Filtering';
+import { useTranslation } from '../translate';
+import Address from './Address';
+import { KickOutEvent } from './index';
+
+interface Props {
+  kicks: KickOutEvent[],
+}
+
+function CurrentList ({ kicks }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+  const [nameFilter, setNameFilter] = useState<string>('');
+
+  const isLoading = useLoadingDelay();
+
+  const kickoutList = useMemo(
+    () => isLoading
+      ? []
+      : kicks,
+    [isLoading, kicks]
+  );
+
+  const headerRef = useRef(
+    [
+      [t('kick-outs'), 'start', 1],
+      [t('era'), 'expand'],
+      [t('kick-out reason'), 'expand'],
+      [t('stats'), 'expand']
+
+    ]
+  );
+
+  return (
+    <Table
+      empty={
+        kickoutList && t<string>('No kick-out events found')
+      }
+      emptySpinner={
+        <>
+          {!kicks && <div>{t<string>('Retrieving kicks')}</div>}
+          {!kickoutList && <div>{t<string>('Preparing kick-out list')}</div>}
+        </>
+      }
+      filter={
+        <div className='staking--optionsBar'>
+          <Filtering
+            nameFilter={nameFilter}
+            setNameFilter={setNameFilter}
+          />
+        </div>
+      }
+      header={headerRef.current}
+    >
+      {kickoutList.map(({ address, era, kickoutReason }): React.ReactNode => (
+        <Address
+          address={address}
+          era={era}
+          filterName={nameFilter}
+          key={address}
+          kickoutReason={kickoutReason}
+        />
+      ))}
+    </Table>
+  );
+}
+
+export default React.memo(CurrentList);

--- a/packages/page-staking/src/Kickouts/CurrentList.tsx
+++ b/packages/page-staking/src/Kickouts/CurrentList.tsx
@@ -1,10 +1,9 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { Table } from '@polkadot/react-components';
-import { useLoadingDelay } from '@polkadot/react-hooks';
 
 import Filtering from '../Filtering';
 import { useTranslation } from '../translate';
@@ -12,21 +11,12 @@ import Address from './Address';
 import { KickOutEvent } from './index';
 
 interface Props {
-  kicks: KickOutEvent[],
+  kicks: KickOutEvent[] | undefined,
 }
 
 function CurrentList ({ kicks }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const [nameFilter, setNameFilter] = useState<string>('');
-
-  const isLoading = useLoadingDelay();
-
-  const kickoutList = useMemo(
-    () => isLoading
-      ? []
-      : kicks,
-    [isLoading, kicks]
-  );
 
   const headerRef = useRef(
     [
@@ -41,12 +31,11 @@ function CurrentList ({ kicks }: Props): React.ReactElement<Props> {
   return (
     <Table
       empty={
-        kickoutList && t<string>('No kick-out events found')
+        kicks !== undefined && kicks.length === 0 && t<string>('No kick-out events found in the past 84 eras')
       }
       emptySpinner={
         <>
-          {!kicks && <div>{t<string>('Retrieving kicks')}</div>}
-          {!kickoutList && <div>{t<string>('Preparing kick-out list')}</div>}
+          {kicks === undefined && <div>{t<string>('Retrieving kick-out events')}</div>}
         </>
       }
       filter={
@@ -59,7 +48,7 @@ function CurrentList ({ kicks }: Props): React.ReactElement<Props> {
       }
       header={headerRef.current}
     >
-      {kickoutList.map(({ address, era, kickoutReason }): React.ReactNode => (
+      {kicks?.map(({ address, era, kickoutReason }): React.ReactNode => (
         <Address
           address={address}
           era={era}

--- a/packages/page-staking/src/Kickouts/Kickouts.tsx
+++ b/packages/page-staking/src/Kickouts/Kickouts.tsx
@@ -1,0 +1,127 @@
+// [object Object]
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { ApiPromise } from '@polkadot/api';
+import { KickOutEvent } from '@polkadot/app-staking/Kickouts/index';
+import useErasStartSessionIndexLookup from '@polkadot/app-staking/Performance/useErasStartSessionIndexLookup';
+import { createNamedHook, useApi } from '@polkadot/react-hooks';
+import { Vec } from '@polkadot/types';
+import { EventRecord, Hash } from '@polkadot/types/interfaces';
+import { Codec } from '@polkadot/types/types';
+
+function parseEvents (eventsInBlocks: Vec<EventRecord>[], api: ApiPromise): [string, string][][][] {
+  return eventsInBlocks.map((events) => {
+    return events.filter(({ event }) => {
+      return event.section == 'elections' && event.method == 'KickOutValidators';
+    })
+      .map(({ event }) => {
+        const data = event.data[0];
+        const raw: Codec[][] = api.createType(data.toRawType(), data);
+
+        return raw.map((value) => {
+          const account = value[0].toString();
+          const reasonTypeAndValue = value[1].toHuman();
+          const reasonType = Object.keys(reasonTypeAndValue as Object)[0];
+          const reasonValue = Object.values(reasonTypeAndValue as Object)[0] as string;
+
+          if (reasonType == 'OtherReason') {
+            return [account, reasonValue];
+          } else if (reasonType == 'InsufficientUptime') {
+            return [account, 'Insufficient uptime in at least ' + reasonValue + ' sessions'];
+          } else {
+            return [account, reasonType + ': ' + reasonValue];
+          }
+        });
+      });
+  });
+}
+
+function useKickOuts (): KickOutEvent[] {
+  const { api } = useApi();
+  // below logic is not able to detect kicks in blocks in which elections has failed,
+  // as staking.erasStartSessionIndex is not populated (new era does not start)
+  const erasStartSessionIndexLookup = useErasStartSessionIndexLookup();
+  const [electionBlockHashes, setElectionBlockHashes] = useState<Hash[]>([]);
+  const [eventsInBlocks, setEventsInBlocks] = useState<[string, string][][][]>([]);
+
+  const [kickOutEvents, setKickOutEvents] = useState<KickOutEvent[]>([]);
+
+  const erasElectionsSessionIndexLookup = useMemo((): [number, number][] => {
+    return erasStartSessionIndexLookup
+      .filter(([era, firstSession]) => firstSession > 0)
+      .map(([era, firstSession]) => [era, firstSession - 1]);
+  },
+  [erasStartSessionIndexLookup]
+  );
+
+  useEffect(() => {
+    if (api && api.consts.elections) {
+      const sessionPeriod = Number(api.consts.elections.sessionPeriod.toString());
+      const promises = erasElectionsSessionIndexLookup.map(([, electionSessionIndex]) => {
+        console.log('Query api at block nr ', electionSessionIndex * sessionPeriod);
+
+        return api.rpc.chain.getBlockHash(electionSessionIndex * sessionPeriod);
+      });
+
+      Promise.all(promises)
+        .then((blockHashes) => setElectionBlockHashes(blockHashes))
+        .catch(console.error);
+    }
+  },
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [api, JSON.stringify(erasElectionsSessionIndexLookup)]
+  );
+
+  useEffect(() => {
+    const promisesApiAtFirstBlock = electionBlockHashes.map((hash) => api.at(hash.toString()));
+
+    Promise.all(promisesApiAtFirstBlock).then((apis) => {
+      const promisesSystemEvents = apis.map((promise) => promise.query.system.events());
+
+      Promise.all(promisesSystemEvents)
+        .then((events: Vec<EventRecord>[]) => {
+          console.log('all events: ', events);
+          const parsedEvents = parseEvents(events, api);
+
+          console.log('parsedEvents', parsedEvents);
+          setEventsInBlocks(parsedEvents);
+        }).catch(console.error);
+    }).catch(console.error);
+  },
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [api, JSON.stringify(electionBlockHashes)]
+  );
+
+  useEffect(() => {
+    if (eventsInBlocks.length > 0 && erasElectionsSessionIndexLookup) {
+      const eventsWithEra: [number, [string, string][][]][] = erasStartSessionIndexLookup.map(function ([era], i) {
+        return [era, eventsInBlocks[i]];
+      });
+        // console.log(eventsWithEra);
+      const events = eventsWithEra.filter(([, kickOutReasonsInEras]) => kickOutReasonsInEras && kickOutReasonsInEras.length > 0)
+        .map(([era, kickOutReasonsInEras]) => {
+          if (kickOutReasonsInEras.length == 1) {
+            return kickOutReasonsInEras[0].map(([address, kickoutReason]) => {
+              return {
+                address,
+                era,
+                kickoutReason
+              };
+            });
+          }
+
+          return [];
+        }).flat().reverse();
+
+      setKickOutEvents(events);
+    }
+  },
+  [api, JSON.stringify(eventsInBlocks), JSON.stringify(erasStartSessionIndexLookup)]
+  );
+
+  return kickOutEvents;
+}
+
+export default createNamedHook('useKickouts', useKickOuts);

--- a/packages/page-staking/src/Kickouts/index.tsx
+++ b/packages/page-staking/src/Kickouts/index.tsx
@@ -1,0 +1,30 @@
+// Copyright 2017-2022 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+import CurrentList from '@polkadot/app-staking/Kickouts/CurrentList';
+
+import useKickOuts from './Kickouts';
+
+export interface KickOutEvent {
+  address: string;
+  era: number;
+  kickoutReason: string;
+}
+
+function KickoutsPage (): React.ReactElement {
+  const kicks = useKickOuts();
+
+  console.log(kicks);
+
+  return (
+    <section>
+      <CurrentList
+        kicks={kicks}
+      />
+    </section>
+  );
+}
+
+export default React.memo(KickoutsPage);

--- a/packages/page-staking/src/Kickouts/index.tsx
+++ b/packages/page-staking/src/Kickouts/index.tsx
@@ -4,6 +4,8 @@
 import React from 'react';
 
 import CurrentList from '@polkadot/app-staking/Kickouts/CurrentList';
+import { MarkWarning } from '@polkadot/react-components';
+import { useApi } from '@polkadot/react-hooks';
 
 import useKickOuts from './Kickouts';
 
@@ -14,9 +16,14 @@ export interface KickOutEvent {
 }
 
 function KickoutsPage (): React.ReactElement {
+  const { api } = useApi();
   const kicks = useKickOuts();
 
-  console.log(kicks);
+  if (!api.runtimeChain.toString().includes('Aleph Zero')) {
+    return (
+      <MarkWarning content={'Unsupported chain.'} />
+    );
+  }
 
   return (
     <section>

--- a/packages/page-staking/src/Performance/useEra.tsx
+++ b/packages/page-staking/src/Performance/useEra.tsx
@@ -3,51 +3,35 @@
 
 import { useMemo } from 'react';
 
-import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
-import { EraIndex } from '@polkadot/types/interfaces';
-import { Option, u32 } from '@polkadot/types-codec';
-
-type SessionIndexEntry = [{ args: [EraIndex] }, Option<u32>];
+import useErasStartSessionIndexLookup from '@polkadot/app-staking/Performance/useErasStartSessionIndexLookup';
+import { createNamedHook } from '@polkadot/react-hooks';
 
 function useEraImpl (inputSession?: number) {
-  const { api } = useApi();
-  const erasStartSessionIndex = useCall<SessionIndexEntry[]>(api.query.staking.erasStartSessionIndex.entries);
+  const erasStartSessionIndexLookup = useErasStartSessionIndexLookup();
 
-  function calculateEra (session: number, erasStartSessionIndex: SessionIndexEntry[]) {
-    const erasStartSessionIndexLookup: [number, number][] = [];
-
-    erasStartSessionIndex.filter(([, values]) => values.isSome)
-      .forEach(([key, values]) => {
-        const eraIndex = key.args[0];
-
-        erasStartSessionIndexLookup.push([eraIndex.toNumber(), values.unwrap().toNumber()]);
-      });
-    erasStartSessionIndexLookup.sort(([eraIndexA], [eraIndexB]) => {
-      return eraIndexA - eraIndexB;
-    });
-
-    for (let i = 0; i < erasStartSessionIndexLookup.length; i++) {
-      const eraIndex = erasStartSessionIndexLookup[i][0];
-      const currentEraSessionStart = erasStartSessionIndexLookup[i][1];
-      const currentEraSessionEnd = i + 1 < erasStartSessionIndexLookup.length ? erasStartSessionIndexLookup[i + 1][1] - 1 : undefined;
+  function calculateEra (session: number, eraToFirstSessionLookup: [number, number][]) {
+    for (let i = 0; i < eraToFirstSessionLookup.length; i++) {
+      const eraIndex = eraToFirstSessionLookup[i][0];
+      const currentEraSessionStart = eraToFirstSessionLookup[i][1];
+      const currentEraSessionEnd = i + 1 < eraToFirstSessionLookup.length ? eraToFirstSessionLookup[i + 1][1] - 1 : undefined;
 
       if (currentEraSessionStart <= session && currentEraSessionEnd && session <= currentEraSessionEnd) {
         return eraIndex;
       }
     }
 
-    const lastErasStartSessionIndexLookup = erasStartSessionIndexLookup.length - 1;
+    const lastErasStartSessionIndexLookup = eraToFirstSessionLookup.length - 1;
 
-    return erasStartSessionIndexLookup[lastErasStartSessionIndexLookup][0];
+    return eraToFirstSessionLookup[lastErasStartSessionIndexLookup][0];
   }
 
   const era = useMemo((): number | undefined => {
-    if (inputSession && erasStartSessionIndex) {
-      return calculateEra(inputSession, erasStartSessionIndex);
+    if (inputSession && erasStartSessionIndexLookup.length > 0) {
+      return calculateEra(inputSession, erasStartSessionIndexLookup);
     }
 
     return undefined;
-  }, [inputSession, erasStartSessionIndex]);
+  }, [inputSession, erasStartSessionIndexLookup]);
 
   return era;
 }

--- a/packages/page-staking/src/Performance/useErasStartSessionIndexLookup.tsx
+++ b/packages/page-staking/src/Performance/useErasStartSessionIndexLookup.tsx
@@ -1,0 +1,40 @@
+// Copyright 2017-2022 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useMemo } from 'react';
+
+import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
+import { EraIndex } from '@polkadot/types/interfaces';
+import { Option, u32 } from '@polkadot/types-codec';
+
+type SessionIndexEntry = [{ args: [EraIndex] }, Option<u32>];
+
+function useErasStartSessionIndexLookupImpl () {
+  const { api } = useApi();
+
+  const erasStartSessionIndex = useCall<SessionIndexEntry[]>(api.query.staking.erasStartSessionIndex.entries);
+
+  const erasStartSessionIndexLookup = useMemo((): [number, number][] => {
+    const result: [number, number][] = [];
+
+    if (erasStartSessionIndex) {
+      erasStartSessionIndex.filter(([, values]) => values.isSome)
+        .forEach(([key, values]) => {
+          const eraIndex = key.args[0];
+
+          result.push([eraIndex.toNumber(), values.unwrap().toNumber()]);
+        });
+      result.sort(([eraIndexA], [eraIndexB]) => {
+        return eraIndexA - eraIndexB;
+      });
+    }
+
+    return result;
+  },
+  [erasStartSessionIndex]
+  );
+
+  return erasStartSessionIndexLookup;
+}
+
+export default createNamedHook('useErasStartSessionIndexLookup', useErasStartSessionIndexLookupImpl);

--- a/packages/page-staking/src/index.tsx
+++ b/packages/page-staking/src/index.tsx
@@ -11,6 +11,7 @@ import { Route, Switch } from 'react-router';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
+import KickoutsPage from '@polkadot/app-staking/Kickouts';
 import PerformancePage from '@polkadot/app-staking/Performance';
 import { HelpOverlay, Tabs } from '@polkadot/react-components';
 import { useAccounts, useApi, useAvailableSlashes, useCall, useCallMulti, useFavorites, useOwnStashInfos } from '@polkadot/react-hooks';
@@ -49,6 +50,7 @@ const OPT_MULTI = {
 function createPathRef (basePath: string): Record<string, string | string[]> {
   return {
     bags: `${basePath}/bags`,
+    kickouts: `${basePath}/kickouts`,
     payout: `${basePath}/payout`,
     performance: `${basePath}/performance`,
     pools: `${basePath}/pools`,
@@ -148,6 +150,10 @@ function StakingApp ({ basePath, className = '' }: Props): React.ReactElement<Pr
     {
       name: 'performance',
       text: t<string>('Performance')
+    },
+    {
+      name: 'kickouts',
+      text: t<string>('Kick-outs')
     }
   ].filter((q): q is { name: string; text: string } => !!q), [api, hasStashes, slashes, t]);
 
@@ -201,6 +207,9 @@ function StakingApp ({ basePath, className = '' }: Props): React.ReactElement<Pr
         </Route>
         <Route path={pathRef.current.performance}>
           <PerformancePage />
+        </Route>
+        <Route path={pathRef.current.kickouts}>
+          <KickoutsPage />
         </Route>
       </Switch>
       <Actions


### PR DESCRIPTION
This PR introduces new tab und er Staking page called `Kick-outs`. The logic queries from API past 84 elections blocks, using `staking.erasStartSessionIndex` storage map to find out what block number is. Then it parses events from such block, looking for `KickOutValidators` event. Parsing of the event is a bit crude, but I was not able to do it more Polkadot-api way. 

This change contains only support for the past kicks, as it was the most important to display. In the future we can add support for current era kicks if neccessary. 

![image](https://user-images.githubusercontent.com/3909333/197511203-561b3c0a-fc76-4390-b980-bc0b8427e664.png)
