### PR TITLE
Added InfoBond widget. Modified WarnBond to be displayed only when staking chillThreshold is set

### DIFF
--- a/packages/page-staking/src/Actions/Account/InfoBond.tsx
+++ b/packages/page-staking/src/Actions/Account/InfoBond.tsx
@@ -27,7 +27,7 @@ function InfoBond ({ minBond, stakingInfo }: Props): React.ReactElement<Props> |
   return isBelow
     ? <article className={'mark'}>
       <Icon icon='circle-info' />
-      {t<string>('Your bonded amount is below the on-chain minimum threshold of {{minBond}}. If you would like to change the nominee, use nomination pools', { replace: { minBond: formatBalance(minBond) } })}
+      {t<string>('Your bonded amount is below the on-chain minimum threshold of {{minBond}} for direct validator nomination. If you would like to change the nominee, use nomination pools where that threshold is lower.', { replace: { minBond: formatBalance(minBond) } })}
     </article>
     : null;
 }

--- a/packages/page-staking/src/Actions/Account/InfoBond.tsx
+++ b/packages/page-staking/src/Actions/Account/InfoBond.tsx
@@ -1,0 +1,34 @@
+// Copyright 2017-2022 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { DeriveStakingAccount } from '@polkadot/api-derive/types';
+import type { BN } from '@polkadot/util';
+
+import React, { useMemo } from 'react';
+
+import Banner from '@polkadot/app-accounts/Accounts/Banner';
+import { formatBalance } from '@polkadot/util';
+
+import { useTranslation } from '../../translate';
+
+interface Props {
+  minBond?: BN;
+  stakingInfo?: DeriveStakingAccount;
+}
+
+function InfoBond ({ minBond, stakingInfo }: Props): React.ReactElement<Props> | null {
+  const { t } = useTranslation();
+
+  const isBelow = useMemo(
+    () => minBond && stakingInfo && stakingInfo.stakingLedger.active.unwrap().lt(minBond),
+    [minBond, stakingInfo]
+  );
+
+  return isBelow
+    ? <Banner>
+      {t<string>('Your bonded amount is below the on-chain minimum threshold of {{minBond}}. If you would like to change the nominee, use nomination pools', { replace: { minBond: formatBalance(minBond) } })}
+    </Banner>
+    : null;
+}
+
+export default React.memo(InfoBond);

--- a/packages/page-staking/src/Actions/Account/InfoBond.tsx
+++ b/packages/page-staking/src/Actions/Account/InfoBond.tsx
@@ -6,7 +6,7 @@ import type { BN } from '@polkadot/util';
 
 import React, { useMemo } from 'react';
 
-import Banner from '@polkadot/app-accounts/Accounts/Banner';
+import Icon from '@polkadot/react-components/Icon';
 import { formatBalance } from '@polkadot/util';
 
 import { useTranslation } from '../../translate';
@@ -25,9 +25,10 @@ function InfoBond ({ minBond, stakingInfo }: Props): React.ReactElement<Props> |
   );
 
   return isBelow
-    ? <Banner>
+    ? <article className={'mark'}>
+      <Icon icon='circle-info' />
       {t<string>('Your bonded amount is below the on-chain minimum threshold of {{minBond}}. If you would like to change the nominee, use nomination pools', { replace: { minBond: formatBalance(minBond) } })}
-    </Banner>
+    </article>
     : null;
 }
 

--- a/packages/page-staking/src/Actions/Account/WarnBond.tsx
+++ b/packages/page-staking/src/Actions/Account/WarnBond.tsx
@@ -7,6 +7,8 @@ import type { BN } from '@polkadot/util';
 import React, { useMemo } from 'react';
 
 import { MarkWarning } from '@polkadot/react-components';
+import { useApi, useCall } from '@polkadot/react-hooks';
+import { Option, u8 } from '@polkadot/types';
 import { formatBalance } from '@polkadot/util';
 
 import { useTranslation } from '../../translate';
@@ -18,10 +20,13 @@ interface Props {
 
 function WarnBond ({ minBond, stakingInfo }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
+  const { api } = useApi();
+
+  const chillThreshold = useCall<Option<u8>>(api.query.staking.chillThreshold);
 
   const isBelow = useMemo(
-    () => minBond && stakingInfo && stakingInfo.stakingLedger.active.unwrap().lt(minBond),
-    [minBond, stakingInfo]
+    () => chillThreshold && chillThreshold.isSome && minBond && stakingInfo && stakingInfo.stakingLedger.active.unwrap().lt(minBond),
+    [minBond, stakingInfo, chillThreshold]
   );
 
   return isBelow

--- a/packages/page-staking/src/Actions/Account/index.tsx
+++ b/packages/page-staking/src/Actions/Account/index.tsx
@@ -374,4 +374,8 @@ export default React.memo(styled(Account)`
     margin-right: 0.25rem;
     vertical-align: inherit;
   }
+  
+  .fa-circle-info {
+    margin-right: 0.5rem;
+  }
 `);

--- a/packages/page-staking/src/Actions/Account/index.tsx
+++ b/packages/page-staking/src/Actions/Account/index.tsx
@@ -11,6 +11,7 @@ import React, { useCallback, useContext, useMemo } from 'react';
 import styled from 'styled-components';
 
 import { ApiPromise } from '@polkadot/api';
+import InfoBond from '@polkadot/app-staking/Actions/Account/InfoBond';
 import { AddressInfo, AddressMini, AddressSmall, Badge, Button, Menu, Popup, StakingBonded, StakingRedeemable, StakingUnbonding, StatusContext, TxButton } from '@polkadot/react-components';
 import { useApi, useCall, useToggle } from '@polkadot/react-hooks';
 import { BN, formatNumber, isFunction } from '@polkadot/util';
@@ -226,6 +227,10 @@ function Account ({ allSlashes, className = '', info: { controllerId, destinatio
                   stashId={stashId}
                 />
                 <WarnBond
+                  minBond={targets.minNominatorBond}
+                  stakingInfo={stakingAccount}
+                />
+                <InfoBond
                   minBond={targets.minNominatorBond}
                   stakingInfo={stakingAccount}
                 />


### PR DESCRIPTION
This PR introduces two functionalities:
* Adding info widget in case a nominator's bond is less than `staking.minNominatorBond`. It can happen when such config is decreased (via sudo `staking.setStakingConfig`)
 
![image](https://user-images.githubusercontent.com/3909333/206125052-afa1fc61-1a61-418b-9ac1-9aa3f6dbfc74.png)

* Change `WarnBond widget to be displayed only when `staking.chillThreshold` is set. Otherwise it makes no sense to display such warning.

![image](https://user-images.githubusercontent.com/3909333/206125445-183f59a2-1742-4713-9cf0-bc05a2002143.png)
