### PR TITLE
Better UX for finalization

### DIFF
--- a/packages/page-explorer/src/BlockHeader.tsx
+++ b/packages/page-explorer/src/BlockHeader.tsx
@@ -3,17 +3,25 @@
 
 import type { HeaderExtended } from '@polkadot/api-derive/types';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 
-import { AddressMini, Digits } from '@polkadot/react-components';
+import { AddressMini, Digits, Icon } from '@polkadot/react-components';
+import { BlockNumber } from '@polkadot/types/interfaces';
 import { formatNumber } from '@polkadot/util';
 
 interface Props {
   value: HeaderExtended;
+  bestNumberFinalized?: BlockNumber;
 }
 
-function BlockHeader ({ value }: Props): React.ReactElement<Props> | null {
+function BlockHeader ({ bestNumberFinalized, value }: Props): React.ReactElement<Props> | null {
+  const isFinalized = useMemo(() => {
+    return bestNumberFinalized && bestNumberFinalized.toNumber() >= value.number.toNumber();
+  },
+  [bestNumberFinalized, value]
+  );
+
   if (!value) {
     return null;
   }
@@ -30,6 +38,14 @@ function BlockHeader ({ value }: Props): React.ReactElement<Props> | null {
         {value.author && (
           <AddressMini value={value.author} />
         )}
+      </td>
+      <td className='finalizedIcon'>
+        {isFinalized
+          ? <Icon
+            className='highlight--color'
+            icon='fa-solid fa-circle-check'
+          />
+          : null}
       </td>
     </tr>
   );

--- a/packages/page-explorer/src/BlockHeader.tsx
+++ b/packages/page-explorer/src/BlockHeader.tsx
@@ -3,30 +3,24 @@
 
 import type { HeaderExtended } from '@polkadot/api-derive/types';
 
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { AddressMini, Digits, Icon } from '@polkadot/react-components';
-import { BlockNumber } from '@polkadot/types/interfaces';
+import IsFinalized from '@polkadot/react-query/IsFinalized';
 import { formatNumber } from '@polkadot/util';
 
 interface Props {
   value: HeaderExtended;
-  bestNumberFinalized?: BlockNumber;
 }
 
-function BlockHeader ({ bestNumberFinalized, value }: Props): React.ReactElement<Props> | null {
-  const isFinalized = useMemo(() => {
-    return bestNumberFinalized && bestNumberFinalized.toNumber() >= value.number.toNumber();
-  },
-  [bestNumberFinalized, value]
-  );
-
+function BlockHeader ({ value }: Props): React.ReactElement<Props> | null {
   if (!value) {
     return null;
   }
 
   const hashHex = value.hash.toHex();
+  const isFinalized = IsFinalized({ blockNumber: value.number.unwrap(), hash: hashHex });
 
   return (
     <tr>

--- a/packages/page-explorer/src/BlockHeader.tsx
+++ b/packages/page-explorer/src/BlockHeader.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 
 import { AddressMini, Digits, Icon } from '@polkadot/react-components';
-import IsFinalized from '@polkadot/react-query/IsFinalized';
+import useIsFinalized from '@polkadot/react-query/useIsFinalized';
 import { formatNumber } from '@polkadot/util';
 
 interface Props {
@@ -15,12 +15,8 @@ interface Props {
 }
 
 function BlockHeader ({ value }: Props): React.ReactElement<Props> | null {
-  if (!value) {
-    return null;
-  }
-
   const hashHex = value.hash.toHex();
-  const isFinalized = IsFinalized({ blockNumber: value.number.unwrap(), hash: hashHex });
+  const isFinalized = useIsFinalized({ blockNumber: value.number.unwrap(), hash: hashHex });
 
   return (
     <tr>

--- a/packages/page-explorer/src/BlockHeaders.tsx
+++ b/packages/page-explorer/src/BlockHeaders.tsx
@@ -6,8 +6,6 @@ import type { HeaderExtended } from '@polkadot/api-derive/types';
 import React, { useRef } from 'react';
 
 import { Table } from '@polkadot/react-components';
-import { useApi, useCall } from '@polkadot/react-hooks';
-import { BlockNumber } from '@polkadot/types/interfaces';
 
 import BlockHeader from './BlockHeader';
 import { useTranslation } from './translate';
@@ -18,8 +16,6 @@ interface Props {
 
 function BlockHeaders ({ headers }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
-  const { api } = useApi();
-  const bestNumberFinalized = useCall<BlockNumber>(api.derive.chain.bestNumberFinalized);
 
   const headerRef = useRef([
     [t('recent blocks'), 'start', 4]
@@ -34,7 +30,6 @@ function BlockHeaders ({ headers }: Props): React.ReactElement<Props> {
         .filter((header) => !!header)
         .map((header): React.ReactNode => (
           <BlockHeader
-            bestNumberFinalized={bestNumberFinalized}
             key={header.number.toString()}
             value={header}
           />

--- a/packages/page-explorer/src/BlockHeaders.tsx
+++ b/packages/page-explorer/src/BlockHeaders.tsx
@@ -6,6 +6,8 @@ import type { HeaderExtended } from '@polkadot/api-derive/types';
 import React, { useRef } from 'react';
 
 import { Table } from '@polkadot/react-components';
+import { useApi, useCall } from '@polkadot/react-hooks';
+import { BlockNumber } from '@polkadot/types/interfaces';
 
 import BlockHeader from './BlockHeader';
 import { useTranslation } from './translate';
@@ -16,9 +18,11 @@ interface Props {
 
 function BlockHeaders ({ headers }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
+  const { api } = useApi();
+  const bestNumberFinalized = useCall<BlockNumber>(api.derive.chain.bestNumberFinalized);
 
   const headerRef = useRef([
-    [t('recent blocks'), 'start', 3]
+    [t('recent blocks'), 'start', 4]
   ]);
 
   return (
@@ -30,6 +34,7 @@ function BlockHeaders ({ headers }: Props): React.ReactElement<Props> {
         .filter((header) => !!header)
         .map((header): React.ReactNode => (
           <BlockHeader
+            bestNumberFinalized={bestNumberFinalized}
             key={header.number.toString()}
             value={header}
           />

--- a/packages/page-explorer/src/BlockInfo/ByHash.tsx
+++ b/packages/page-explorer/src/BlockInfo/ByHash.tsx
@@ -11,7 +11,7 @@ import { Link } from 'react-router-dom';
 import { AddressSmall, Columar, LinkExternal, MarkWarning, Table } from '@polkadot/react-components';
 import { useApi, useIsMountedRef } from '@polkadot/react-hooks';
 import { convertWeight } from '@polkadot/react-hooks/useWeight';
-import IsFinalized from '@polkadot/react-query/IsFinalized';
+import useIsFinalized from '@polkadot/react-query/useIsFinalized';
 import { formatNumber } from '@polkadot/util';
 
 import Events from '../Events';
@@ -111,7 +111,7 @@ function BlockByHash ({ className = '', error, value }: Props): React.ReactEleme
   const parentHash = getHeader?.parentHash.toHex();
   const hasParent = !getHeader?.parentHash.isEmpty;
 
-  const isFinalized = IsFinalized({ blockNumber, hash: value });
+  const isFinalized = useIsFinalized({ blockNumber, hash: value });
 
   return (
     <div className={className}>

--- a/packages/page-explorer/src/BlockInfo/ByHash.tsx
+++ b/packages/page-explorer/src/BlockInfo/ByHash.tsx
@@ -9,9 +9,9 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { AddressSmall, Columar, LinkExternal, MarkWarning, Table } from '@polkadot/react-components';
-import { useApi, useCall, useIsMountedRef } from '@polkadot/react-hooks';
+import { useApi, useIsMountedRef } from '@polkadot/react-hooks';
 import { convertWeight } from '@polkadot/react-hooks/useWeight';
-import { BlockNumber } from '@polkadot/types/interfaces';
+import IsFinalized from '@polkadot/react-query/IsFinalized';
 import { formatNumber } from '@polkadot/util';
 
 import Events from '../Events';
@@ -56,7 +56,6 @@ function BlockByHash ({ className = '', error, value }: Props): React.ReactEleme
   const [{ events, getBlock, getHeader, runtimeVersion }, setState] = useState<State>({});
   const [blkError, setBlkError] = useState<Error | null | undefined>(error);
   const [evtError, setEvtError] = useState<Error | null | undefined>();
-  const bestNumberFinalized = useCall<BlockNumber>(api.derive.chain.bestNumberFinalized);
 
   const [isVersionCurrent, maxBlockWeight] = useMemo(
     () => [
@@ -112,15 +111,7 @@ function BlockByHash ({ className = '', error, value }: Props): React.ReactEleme
   const parentHash = getHeader?.parentHash.toHex();
   const hasParent = !getHeader?.parentHash.isEmpty;
 
-  const isFinalized = useMemo(() => {
-    if (bestNumberFinalized && blockNumber) {
-      return bestNumberFinalized.toNumber() >= blockNumber.toNumber();
-    }
-
-    return undefined;
-  },
-  [bestNumberFinalized, blockNumber]
-  );
+  const isFinalized = IsFinalized({ blockNumber, hash: value });
 
   return (
     <div className={className}>

--- a/packages/page-explorer/src/Summary.tsx
+++ b/packages/page-explorer/src/Summary.tsx
@@ -54,11 +54,9 @@ function Summary ({ eventCount }: Props): React.ReactElement {
         >
           {formatNumber(eventCount)}
         </CardSummary>
-        {api.query.grandpa && (
-          <CardSummary label={t<string>('finalized')}>
-            <BestFinalized />
-          </CardSummary>
-        )}
+        <CardSummary label={t<string>('finalized')}>
+          <BestFinalized />
+        </CardSummary>
         <CardSummary label={t<string>('best')}>
           <BestNumber />
         </CardSummary>

--- a/packages/react-components/src/Status/index.tsx
+++ b/packages/react-components/src/Status/index.tsx
@@ -43,9 +43,11 @@ function signerIconName (status: QueueTxStatus): IconName {
 
     case 'completed':
     case 'inblock':
-    case 'finalized':
     case 'sent':
       return 'check';
+
+    case 'finalized':
+      return 'circle-check';
 
     case 'dropped':
     case 'invalid':

--- a/packages/react-query/src/IsFinalized.tsx
+++ b/packages/react-query/src/IsFinalized.tsx
@@ -1,0 +1,43 @@
+// Copyright 2017-2022 @polkadot/react-query authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { BlockNumber } from '@polkadot/types/interfaces';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
+import { Hash } from '@polkadot/types/interfaces';
+
+interface Props {
+  blockNumber?: BlockNumber;
+  hash: string | null | undefined;
+}
+
+function IsFinalizedImpl ({ blockNumber, hash }: Props): boolean | undefined {
+  const { api } = useApi();
+  const bestNumberFinalized = useCall<BlockNumber>(api.derive.chain.bestNumberFinalized);
+  const [canonicalChainHash, setCanonicalHash] = useState<Hash | undefined>(undefined);
+
+  useEffect((): void => {
+    api.rpc.chain
+      .getBlockHash(blockNumber)
+      .then((result): void => {
+        setCanonicalHash(result);
+      })
+      .catch(console.error);
+  }, [api, blockNumber]);
+
+  const isFinalized = useMemo(() => {
+    if (bestNumberFinalized && blockNumber && canonicalChainHash && hash) {
+      return bestNumberFinalized.toNumber() >= blockNumber.toNumber() && canonicalChainHash.toString() === hash;
+    }
+
+    return undefined;
+  },
+  [bestNumberFinalized, blockNumber, canonicalChainHash, hash]
+  );
+
+  return isFinalized;
+}
+
+export default createNamedHook('IsFinalized', IsFinalizedImpl);

--- a/packages/react-query/src/useIsFinalized.tsx
+++ b/packages/react-query/src/useIsFinalized.tsx
@@ -40,4 +40,4 @@ function IsFinalizedImpl ({ blockNumber, hash }: Props): boolean | undefined {
   return isFinalized;
 }
 
-export default createNamedHook('IsFinalized', IsFinalizedImpl);
+export default createNamedHook('useIsFinalized', IsFinalizedImpl);


### PR DESCRIPTION
This PR introduces for UX changes that aims to make finzalization in Aleph chain has better UX.

1. Added Finalization widget in page explorer, next to best block number. It shoes what node think the best finalized number block is, namely the call `rpc.chain.getFinalizedHead` converted to a block number
2. Added a fourth column to a table which contains block number, block author, block hash. The icon is showed only for finalized blocks.

![image](https://user-images.githubusercontent.com/3909333/206406310-5fbc64ed-8a5b-41ce-8731-ccd7f0bb4f78.png)

3. Added "Block not finalized!" warning to Block details, that disappears when block is finalized

![image](https://user-images.githubusercontent.com/3909333/206407964-2e89febb-9d1b-4119-b4a0-807f6b0656eb.png)

4. Changed icon for pop up when tx is finalized, so it's distinguished between `inblock` and `finalized`

![image](https://user-images.githubusercontent.com/3909333/206408629-2fb38c36-54f0-4630-bacf-ad2fa678e918.png)

