### PR TITLE
Reworked Staking/Overiew as per latest requirements

### DIFF
--- a/packages/page-staking/src/Validators/CurrentList.tsx
+++ b/packages/page-staking/src/Validators/CurrentList.tsx
@@ -1,20 +1,16 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveHeartbeats, DeriveStakingOverview } from '@polkadot/api-derive/types';
-import type { Authors } from '@polkadot/react-query/BlockAuthors';
+import type { DeriveHeartbeats } from '@polkadot/api-derive/types';
 import type { AccountId } from '@polkadot/types/interfaces';
-import type { BN } from '@polkadot/util';
 import type { NominatedByMap, SortedTargets, ValidatorInfo } from '../types';
 
-import React, { useContext, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 
 import { Table } from '@polkadot/react-components';
-import { useApi, useLoadingDelay } from '@polkadot/react-hooks';
-import { BlockAuthorsContext } from '@polkadot/react-query';
+import { useLoadingDelay } from '@polkadot/react-hooks';
 
 import Filtering from '../Filtering';
-import Legend from '../Legend';
 import { useTranslation } from '../translate';
 import Address from './Address';
 
@@ -22,30 +18,23 @@ interface Props {
   className?: string;
   favorites: string[];
   hasQueries: boolean;
-  isIntentions?: boolean;
   isIntentionsTrigger?: boolean;
   isOwn: boolean;
-  minCommission?: BN;
   nominatedBy?: NominatedByMap;
   ownStashIds?: string[];
-  paraValidators?: Record<string, boolean>;
   recentlyOnline?: DeriveHeartbeats;
   setNominators?: (nominators: string[]) => void;
-  stakingOverview?: DeriveStakingOverview;
   targets: SortedTargets;
   toggleFavorite: (address: string) => void;
 }
 
-type AccountExtend = [string, boolean, boolean];
+type AccountExtend = [string, boolean];
 
 interface Filtered {
   validators?: AccountExtend[];
-  waiting?: AccountExtend[];
 }
 
-const EmptyAuthorsContext: React.Context<Authors> = React.createContext<Authors>({ byAuthor: {}, eraPoints: {}, lastBlockAuthors: [], lastHeaders: [] });
-
-function filterAccounts (isOwn: boolean, accounts: string[] = [], ownStashIds: string[] = [], elected: string[], favorites: string[], without: string[]): AccountExtend[] {
+function filterAccounts (isOwn: boolean, accounts: string[] = [], ownStashIds: string[] = [], favorites: string[], without: string[]): AccountExtend[] {
   return accounts
     .filter((accountId) =>
       !without.includes(accountId) && (
@@ -55,10 +44,9 @@ function filterAccounts (isOwn: boolean, accounts: string[] = [], ownStashIds: s
     )
     .map((accountId): AccountExtend => [
       accountId,
-      elected.includes(accountId),
       favorites.includes(accountId)
     ])
-    .sort(([accA,, isFavA]: AccountExtend, [accB,, isFavB]: AccountExtend): number => {
+    .sort(([accA, isFavA]: AccountExtend, [accB, isFavB]: AccountExtend): number => {
       const isStashA = ownStashIds.includes(accA);
       const isStashB = ownStashIds.includes(accB);
 
@@ -80,19 +68,15 @@ function accountsToString (accounts: AccountId[]): string[] {
   return result;
 }
 
-function getFiltered (isOwn: boolean, stakingOverview: DeriveStakingOverview | undefined, favorites: string[], next?: string[], ownStashIds?: string[]): Filtered {
-  if (!stakingOverview) {
+function getFiltered (isOwn: boolean, favorites: string[], targets: SortedTargets, ownStashIds?: string[]): Filtered {
+  if (!targets.eraValidators) {
     return {};
   }
 
-  const allElected = accountsToString(stakingOverview.nextElected);
-  const validatorIds = accountsToString(stakingOverview.validators);
+  const eraValidators = accountsToString(targets.eraValidators.reserved.concat(targets.eraValidators.nonReserved));
 
   return {
-    validators: filterAccounts(isOwn, validatorIds, ownStashIds, allElected, favorites, []),
-    waiting: filterAccounts(isOwn, allElected, ownStashIds, allElected, favorites, validatorIds).concat(
-      filterAccounts(isOwn, next, ownStashIds, [], favorites, allElected)
-    )
+    validators: filterAccounts(isOwn, eraValidators, ownStashIds, favorites, [])
   };
 }
 
@@ -108,29 +92,23 @@ function mapValidators (infos: ValidatorInfo[]): Record<string, ValidatorInfo> {
   return result;
 }
 
-const DEFAULT_PARAS = {};
-
-function CurrentList ({ className, favorites, hasQueries, isIntentions, isOwn, minCommission, nominatedBy, ownStashIds, paraValidators = DEFAULT_PARAS, recentlyOnline, stakingOverview, targets, toggleFavorite }: Props): React.ReactElement<Props> | null {
+function CurrentList ({ className, favorites, hasQueries, isOwn, nominatedBy, ownStashIds, recentlyOnline, targets, toggleFavorite }: Props): React.ReactElement<Props> | null {
   const { t } = useTranslation();
-  const { api } = useApi();
-  const { byAuthor } = useContext(isIntentions ? EmptyAuthorsContext : BlockAuthorsContext);
   const [nameFilter, setNameFilter] = useState<string>('');
 
   // we have a very large list, so we use a loading delay
   const isLoading = useLoadingDelay();
 
-  const { validators, waiting } = useMemo(
-    () => getFiltered(isOwn, stakingOverview, favorites, targets.waitingIds, ownStashIds),
-    [favorites, isOwn, ownStashIds, stakingOverview, targets]
+  const { validators } = useMemo(
+    () => getFiltered(isOwn, favorites, targets, ownStashIds),
+    [favorites, isOwn, ownStashIds, targets]
   );
 
   const list = useMemo(
     () => isLoading
       ? undefined
-      : isIntentions
-        ? nominatedBy && waiting
-        : validators,
-    [isIntentions, isLoading, nominatedBy, validators, waiting]
+      : nominatedBy && validators,
+    [isLoading, nominatedBy, validators]
   );
 
   const infoMap = useMemo(
@@ -139,41 +117,27 @@ function CurrentList ({ className, favorites, hasQueries, isIntentions, isOwn, m
   );
 
   const headerRef = useRef(
-    isIntentions
-      ? [
-        [t('intentions'), 'start', 2],
-        [t('nominators'), 'expand'],
-        [t('commission'), 'number'],
-        [],
-        []
-      ]
-      : [
-        [t('validators'), 'start', 2],
-        [t('other stake'), 'expand'],
-        [t('own stake'), 'media--1100'],
-        [t('commission')],
-        [t('last #')],
-        [],
-        [undefined, 'media--1200']
-      ]
+    [
+      [t('validators'), 'start', 2],
+      [t('other stake'), 'expand'],
+      [t('own stake'), 'media--1100'],
+      [t('nominators'), 'expand'],
+      [t('commission')],
+      [],
+      [undefined, 'media--1200']
+    ]
   );
 
   return (
     <Table
       className={className}
       empty={
-        isIntentions
-          ? list && t<string>('No waiting validators found')
-          : list && recentlyOnline && infoMap && t<string>('No active validators found')
+        list && recentlyOnline && infoMap && t<string>('No active validators found')
       }
       emptySpinner={
         <>
-          {!waiting && <div>{t<string>('Retrieving validators')}</div>}
           {!infoMap && <div>{t<string>('Retrieving validator info')}</div>}
-          {isIntentions
-            ? !nominatedBy && <div>{t<string>('Retrieving nominators')}</div>
-            : !recentlyOnline && <div>{t<string>('Retrieving online status')}</div>
-          }
+          {!nominatedBy && <div>{t<string>('Retrieving nominators')}</div>}
           {!list && <div>{t<string>('Preparing validator list')}</div>}
         </>
       }
@@ -184,27 +148,15 @@ function CurrentList ({ className, favorites, hasQueries, isIntentions, isOwn, m
         />
       }
       header={headerRef.current}
-      legend={
-        <Legend
-          isRelay={!isIntentions && !!(api.query.parasShared || api.query.shared)?.activeValidatorIndices}
-          minCommission={minCommission}
-        />
-      }
     >
-      {list && list.map(([address, isElected, isFavorite]): React.ReactNode => (
+      {list && list.map(([address, isFavorite]): React.ReactNode => (
         <Address
           address={address}
           filterName={nameFilter}
           hasQueries={hasQueries}
-          isElected={isElected}
           isFavorite={isFavorite}
-          isMain={!isIntentions}
-          isPara={isIntentions ? false : paraValidators[address]}
           key={address}
-          lastBlock={byAuthor[address]}
-          minCommission={minCommission}
           nominatedBy={nominatedBy?.[address]}
-          recentlyOnline={recentlyOnline?.[address]}
           toggleFavorite={toggleFavorite}
           validatorInfo={infoMap?.[address]}
         />

--- a/packages/page-staking/src/Validators/Summary.tsx
+++ b/packages/page-staking/src/Validators/Summary.tsx
@@ -1,8 +1,7 @@
 // Copyright 2017-2022 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DeriveStakingOverview } from '@polkadot/api-derive/types';
-import type { SortedTargets } from '../types';
+import type { EraValidators, SortedTargets } from '../types';
 
 import React from 'react';
 import styled from 'styled-components';
@@ -16,28 +15,22 @@ import { useTranslation } from '../translate';
 interface Props {
   className?: string;
   nominators?: string[];
-  stakingOverview?: DeriveStakingOverview;
   targets: SortedTargets;
+  eraValidators: EraValidators;
 }
 
-function Summary ({ className = '', stakingOverview, targets: { counterForNominators, inflation: { idealStake, inflation, stakedFraction }, nominators, waitingIds } }: Props): React.ReactElement<Props> {
+function Summary ({ className = '', eraValidators, targets: { counterForNominators, inflation: { idealStake, inflation, stakedFraction }, nominators } }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
 
   return (
     <SummaryBox className={className}>
       <section>
-        <CardSummary label={t<string>('validators')}>
-          {stakingOverview
-            ? <>{formatNumber(stakingOverview.validators.length)}&nbsp;/&nbsp;{formatNumber(stakingOverview.validatorCount)}</>
-            : <Spinner noLabel />
-          }
-        </CardSummary>
         <CardSummary
           className='media--900'
-          label={t<string>('waiting')}
+          label={t<string>('era validators')}
         >
-          {waitingIds
-            ? formatNumber(waitingIds.length)
+          {eraValidators
+            ? formatNumber(eraValidators.reserved.length + eraValidators.nonReserved.length)
             : <Spinner noLabel />
           }
         </CardSummary>

--- a/packages/page-staking/src/Validators/Summary.tsx
+++ b/packages/page-staking/src/Validators/Summary.tsx
@@ -56,14 +56,6 @@ function Summary ({ className = '', eraValidators, targets: { counterForNominato
         </CardSummary>
       </section>
       <section>
-        {(idealStake > 0) && Number.isFinite(idealStake) && (
-          <CardSummary
-            className='media--1400'
-            label={t<string>('ideal staked')}
-          >
-            <>{(idealStake * 100).toFixed(1)}%</>
-          </CardSummary>
-        )}
         {(stakedFraction > 0) && (
           <CardSummary
             className='media--1300'

--- a/packages/page-staking/src/Validators/index.tsx
+++ b/packages/page-staking/src/Validators/index.tsx
@@ -3,10 +3,9 @@
 
 import type { DeriveHeartbeats, DeriveStakingOverview } from '@polkadot/api-derive/types';
 import type { StakerState } from '@polkadot/react-hooks/types';
-import type { BN } from '@polkadot/util';
 import type { NominatedByMap, SortedTargets } from '../types';
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { Button, ToggleGroup } from '@polkadot/react-components';
 import { useApi, useCall } from '@polkadot/react-hooks';
@@ -21,10 +20,8 @@ interface Props {
   favorites: string[];
   hasAccounts: boolean;
   hasQueries: boolean;
-  minCommission?: BN;
   nominatedBy?: NominatedByMap;
   ownStashes?: StakerState[];
-  paraValidators?: Record<string, boolean>;
   stakingOverview?: DeriveStakingOverview;
   targets: SortedTargets;
   toggleFavorite: (address: string) => void;
@@ -32,35 +29,25 @@ interface Props {
   toggleNominatedBy: () => void;
 }
 
-function Overview ({ className = '', favorites, hasAccounts, hasQueries, minCommission, nominatedBy, ownStashes, paraValidators, stakingOverview, targets, toggleFavorite, toggleLedger, toggleNominatedBy }: Props): React.ReactElement<Props> {
+function Overview ({ className = '', favorites, hasAccounts, hasQueries, nominatedBy, ownStashes, stakingOverview, targets, toggleFavorite, toggleLedger, toggleNominatedBy }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
-  const [intentIndex, _setIntentIndex] = useState(0);
   const [typeIndex, setTypeIndex] = useState(1);
   const recentlyOnline = useCall<DeriveHeartbeats>(api.derive.imOnline?.receivedHeartbeats);
-
-  const setIntentIndex = useCallback(
-    (index: number): void => {
-      index && toggleNominatedBy();
-      _setIntentIndex(index);
-    },
-    [toggleNominatedBy]
-  );
 
   const filterOptions = useRef([
     { text: t('Own validators'), value: 'mine' },
     { text: t('All validators'), value: 'all' }
   ]);
 
-  const intentOptions = useRef([
-    { text: t('Active'), value: 'active' },
-    { text: t('Waiting'), value: 'waiting' }
-  ]);
-
   const ownStashIds = useMemo(
     () => ownStashes && ownStashes.map(({ stashId }) => stashId),
     [ownStashes]
   );
+
+  useEffect((): void => {
+    toggleNominatedBy && toggleNominatedBy();
+  }, [toggleNominatedBy]);
 
   useEffect((): void => {
     toggleLedger && toggleLedger();
@@ -71,6 +58,7 @@ function Overview ({ className = '', favorites, hasAccounts, hasQueries, minComm
   return (
     <div className={`staking--Overview ${className}`}>
       <Summary
+        eraValidators={targets.eraValidators}
         stakingOverview={stakingOverview}
         targets={targets}
       />
@@ -83,24 +71,15 @@ function Overview ({ className = '', favorites, hasAccounts, hasQueries, minComm
           options={filterOptions.current}
           value={typeIndex}
         />
-        <ToggleGroup
-          onChange={setIntentIndex}
-          options={intentOptions.current}
-          value={intentIndex}
-        />
       </Button.Group>
       <CurrentList
         favorites={favorites}
         hasQueries={hasQueries}
-        isIntentions={intentIndex === 1}
         isOwn={isOwn}
-        key={intentIndex}
-        minCommission={intentIndex === 0 ? minCommission : undefined}
-        nominatedBy={intentIndex === 1 ? nominatedBy : undefined}
+        key={0}
+        nominatedBy={nominatedBy}
         ownStashIds={ownStashIds}
-        paraValidators={paraValidators}
-        recentlyOnline={intentIndex === 0 ? recentlyOnline : undefined}
-        stakingOverview={stakingOverview}
+        recentlyOnline={recentlyOnline}
         targets={targets}
         toggleFavorite={toggleFavorite}
       />

--- a/packages/page-staking/src/index.tsx
+++ b/packages/page-staking/src/index.tsx
@@ -73,7 +73,7 @@ function StakingApp ({ basePath, className = '' }: Props): React.ReactElement<Pr
   const [loadNominations, setLoadNominations] = useState(false);
   const nominatedBy = useNominations(loadNominations);
   const stakingOverview = useCall<DeriveStakingOverview>(api.derive.staking.overview);
-  const [isInElection, minCommission, paraValidators] = useCallMulti<[boolean, BN | undefined, Record<string, boolean>]>([
+  const [isInElection, minCommission] = useCallMulti<[boolean, BN | undefined, Record<string, boolean>]>([
     api.query.staking.eraElectionStatus,
     api.query.staking.minCommission,
     api.query.session.validators,
@@ -225,10 +225,8 @@ function StakingApp ({ basePath, className = '' }: Props): React.ReactElement<Pr
         favorites={favorites}
         hasAccounts={hasAccounts}
         hasQueries={hasQueries}
-        minCommission={minCommission}
         nominatedBy={nominatedBy}
         ownStashes={ownStashes}
-        paraValidators={paraValidators}
         stakingOverview={stakingOverview}
         targets={targets}
         toggleFavorite={toggleFavorite}

--- a/packages/page-staking/src/types.ts
+++ b/packages/page-staking/src/types.ts
@@ -7,6 +7,8 @@ import type { AccountId, Balance, BlockNumber, EraIndex, Exposure, Hash, Session
 import type { PalletNominationPoolsPoolMember } from '@polkadot/types/lookup';
 import type { BN } from '@polkadot/util';
 
+import { Vec } from '@polkadot/types';
+
 export type Nominators = Record<string, string[]>;
 
 export type AccountFilter = 'all' | 'controller' | 'session' | 'stash' | 'unbonded';
@@ -46,6 +48,11 @@ interface ValidatorInfoRank {
   rankReward: number;
 }
 
+export interface EraValidators {
+  reserved: Vec<AccountId>;
+  nonReserved: Vec<AccountId>;
+}
+
 export interface ValidatorInfo extends ValidatorInfoRank {
   accountId: AccountId;
   bondOther: BN;
@@ -78,6 +85,7 @@ export interface SortedTargets {
   avgStaked?: BN;
   counterForNominators?: BN;
   counterForValidators?: BN;
+  eraValidators?: EraValidators;
   electedIds?: string[];
   historyDepth?: BN;
   inflation: Inflation;

--- a/packages/page-staking/src/useSortedTargets.ts
+++ b/packages/page-staking/src/useSortedTargets.ts
@@ -5,7 +5,7 @@ import type { ApiPromise } from '@polkadot/api';
 import type { DeriveSessionInfo, DeriveStakingElected, DeriveStakingWaiting } from '@polkadot/api-derive/types';
 import type { Inflation } from '@polkadot/react-hooks/types';
 import type { Option, u32 } from '@polkadot/types';
-import type { SortedTargets, TargetSortBy, ValidatorInfo } from './types';
+import type { EraValidators, SortedTargets, TargetSortBy, ValidatorInfo } from './types';
 
 import { useMemo } from 'react';
 
@@ -283,6 +283,7 @@ function useSortedTargetsImpl (favorites: string[], withLedger: boolean): Sorted
   const electedInfo = useCall<DeriveStakingElected>(api.derive.staking.electedInfo, [{ ...DEFAULT_FLAGS_ELECTED, withLedger }]);
   const waitingInfo = useCall<DeriveStakingWaiting>(api.derive.staking.waitingInfo, [{ ...DEFAULT_FLAGS_WAITING, withLedger }]);
   const lastEraInfo = useCall<LastEra>(api.derive.session.info, undefined, OPT_ERA);
+  const eraValidators = useCall<EraValidators>(api.query.elections.currentEraValidators);
 
   const baseInfo = useMemo(
     () => electedInfo && lastEraInfo && totalIssuance && waitingInfo
@@ -297,6 +298,7 @@ function useSortedTargetsImpl (favorites: string[], withLedger: boolean): Sorted
     (): SortedTargets => ({
       counterForNominators,
       counterForValidators,
+      eraValidators,
       historyDepth: api.consts.staking.historyDepth || historyDepth,
       inflation,
       maxNominatorsCount,
@@ -311,7 +313,7 @@ function useSortedTargetsImpl (favorites: string[], withLedger: boolean): Sorted
           : baseInfo
       )
     }),
-    [api, baseInfo, counterForNominators, counterForValidators, historyDepth, inflation, maxNominatorsCount, maxValidatorsCount, minNominatorBond, minValidatorBond]
+    [api, baseInfo, counterForNominators, counterForValidators, historyDepth, inflation, maxNominatorsCount, maxValidatorsCount, minNominatorBond, minValidatorBond, eraValidators]
   );
 }
 


### PR DESCRIPTION
This PR introduces changes to display the staking overview to reflect to the validator elections system used in AlephZero. 
 
* remove `validators` to committee validators from the summary and rename `waiting` to `era validators` 
* remove `Active` and `Waiting` buttons
* display columns `other stake`, `own stake`, `nominators`, `commission`,
* remove displaying all icons, including the blue one as it was confusing to the users
* list of the validators displayed would be those which are elected by elections pallet (so effectively `elections.currentEraValidators.reserved` + `elections.currentEraValidators.nonReserved`)

![image](https://user-images.githubusercontent.com/3909333/207023154-610090e9-6b68-4910-95cd-649622f30d84.png)
