### PR TITLE
Remove some Staking/Targets toggles

### DIFF
--- a/packages/page-staking/src/Targets/index.tsx
+++ b/packages/page-staking/src/Targets/index.tsx
@@ -4,15 +4,13 @@
 import type { DeriveHasIdentity, DeriveStakingOverview } from '@polkadot/api-derive/types';
 import type { StakerState } from '@polkadot/react-hooks/types';
 import type { u32 } from '@polkadot/types-codec';
-import type { BN } from '@polkadot/util';
 import type { NominatedByMap, SortedTargets, TargetSortBy, ValidatorInfo } from '../types';
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 import { Button, Icon, Table, Toggle } from '@polkadot/react-components';
-import { useApi, useAvailableSlashes, useBlocksPerDays, useSavedFlags } from '@polkadot/react-hooks';
-import { BN_HUNDRED } from '@polkadot/util';
+import { useApi, useAvailableSlashes, useSavedFlags } from '@polkadot/react-hooks';
 
 import { MAX_NOMINATIONS } from '../constants';
 import ElectionBanner from '../ElectionBanner';
@@ -39,17 +37,7 @@ interface Props {
 
 interface SavedFlags {
   withElected: boolean;
-  withGroup: boolean;
   withIdentity: boolean;
-  withPayout: boolean;
-  withoutComm: boolean;
-  withoutOver: boolean;
-}
-
-interface Flags extends SavedFlags {
-  daysPayout: BN;
-  isBabe: boolean;
-  maxPaid: BN | undefined;
 }
 
 interface SortState {
@@ -61,81 +49,16 @@ const CLASSES: Record<string, string> = {
   rankBondOther: 'media--1600',
   rankBondOwn: 'media--900'
 };
-const MAX_CAP_PERCENT = 100; // 75 if only using numNominators
-const MAX_COMM_PERCENT = 10; // -1 for median
-const MAX_DAYS = 7;
 const SORT_KEYS = ['rankBondTotal', 'rankBondOwn', 'rankBondOther', 'rankOverall'];
 
-function overlapsDisplay (displays: (string[])[], test: string[]): boolean {
-  return displays.some((d) =>
-    d.length === test.length
-      ? d.length === 1
-        ? d[0] === test[0]
-        : d.reduce((c, p, i) => c + (p === test[i] ? 1 : 0), 0) >= (test.length - 1)
-      : false
-  );
-}
-
-function applyFilter (validators: ValidatorInfo[], medianComm: number, allIdentity: Record<string, DeriveHasIdentity>, { daysPayout, isBabe, maxPaid, withElected, withGroup, withIdentity, withPayout, withoutComm, withoutOver }: Flags, nominatedBy?: NominatedByMap): ValidatorInfo[] {
-  const displays: (string[])[] = [];
-  const parentIds: string[] = [];
-
-  return validators.filter(({ accountId, commissionPer, isElected, isFavorite, lastPayout, numNominators }): boolean => {
-    if (isFavorite) {
-      return true;
-    }
-
+function applyFilter (validators: ValidatorInfo[], allIdentity: Record<string, DeriveHasIdentity>, { withElected, withIdentity }: SavedFlags): ValidatorInfo[] {
+  return validators.filter(({ accountId, isElected, isFavorite }): boolean => {
     const stashId = accountId.toString();
     const thisIdentity = allIdentity[stashId];
-    const nomCount = numNominators || nominatedBy?.[stashId]?.length || 0;
 
-    if (
-      (!withElected || isElected) &&
-      (!withIdentity || !!thisIdentity?.hasIdentity) &&
-      (!withPayout || !isBabe || (!!lastPayout && daysPayout.gte(lastPayout))) &&
-      (!withoutComm || (
-        MAX_COMM_PERCENT > 0
-          ? (commissionPer <= MAX_COMM_PERCENT)
-          : (!medianComm || (commissionPer <= medianComm)))
-      ) &&
-      (!withoutOver || !maxPaid || maxPaid.muln(MAX_CAP_PERCENT).div(BN_HUNDRED).gten(nomCount))
-    ) {
-      if (!withGroup) {
-        return true;
-      } else if (!thisIdentity || !thisIdentity.hasIdentity) {
-        parentIds.push(stashId);
-
-        return true;
-      } else if (!thisIdentity.parentId) {
-        if (!parentIds.includes(stashId)) {
-          if (thisIdentity.display) {
-            const sanitized = thisIdentity.display
-              .replace(/[^\x20-\x7E]/g, '')
-              .replace(/-/g, ' ')
-              .replace(/_/g, ' ')
-              .split(' ')
-              .map((p) => p.trim())
-              .filter((v) => !!v);
-
-            if (overlapsDisplay(displays, sanitized)) {
-              return false;
-            }
-
-            displays.push(sanitized);
-          }
-
-          parentIds.push(stashId);
-
-          return true;
-        }
-      } else if (!parentIds.includes(thisIdentity.parentId)) {
-        parentIds.push(thisIdentity.parentId);
-
-        return true;
-      }
-    }
-
-    return false;
+    return isFavorite ||
+      ((!withElected || isElected) &&
+      (!withIdentity || !!thisIdentity?.hasIdentity));
   });
 }
 
@@ -183,22 +106,17 @@ function selectProfitable (list: ValidatorInfo[], maxNominations: number): strin
 
 const DEFAULT_FLAGS = {
   withElected: false,
-  withGroup: true,
-  withIdentity: false,
-  withPayout: false,
-  withoutComm: true,
-  withoutOver: true
+  withIdentity: false
 };
 
 const DEFAULT_NAME = { isQueryFiltered: false, nameFilter: '' };
 
 const DEFAULT_SORT: SortState = { sortBy: 'rankOverall', sortFromMax: true };
 
-function Targets ({ className = '', isInElection, nominatedBy, ownStashes, targets: { avgStaked, inflation: { stakedReturn }, lastEra, lowStaked, medianComm, minNominated, minNominatorBond, nominators, totalIssuance, totalStaked, validatorIds, validators }, toggleFavorite, toggleLedger, toggleNominatedBy }: Props): React.ReactElement<Props> {
+function Targets ({ className = '', isInElection, nominatedBy, ownStashes, targets: { avgStaked, inflation: { stakedReturn }, lastEra, lowStaked, minNominated, minNominatorBond, nominators, totalIssuance, totalStaked, validatorIds, validators }, toggleFavorite, toggleLedger, toggleNominatedBy }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api } = useApi();
   const allSlashes = useAvailableSlashes();
-  const daysPayout = useBlocksPerDays(MAX_DAYS);
   const ownNominators = useOwnNominators(ownStashes);
   const allIdentity = useIdentities(validatorIds);
   const [selected, setSelected] = useState<string[]>([]);
@@ -217,18 +135,14 @@ function Targets ({ className = '', isInElection, nominatedBy, ownStashes, targe
   const flags = useMemo(
     () => ({
       ...toggles,
-      daysPayout,
-      isBabe: !!api.consts.babe,
-      isQueryFiltered,
-      maxPaid: api.consts.staking?.maxNominatorRewardedPerValidator
+      isQueryFiltered
     }),
-    [api, daysPayout, isQueryFiltered, toggles]
+    [isQueryFiltered, toggles]
   );
 
   const filtered = useMemo(
-    () => allIdentity && validators && nominatedBy &&
-      applyFilter(validators, medianComm, allIdentity, flags, nominatedBy),
-    [allIdentity, flags, medianComm, nominatedBy, validators]
+    () => allIdentity && validators && applyFilter(validators, allIdentity, flags),
+    [allIdentity, flags, validators]
   );
 
   // We are using an effect here to get this async. Sorting will have a double-render, however it allows
@@ -290,7 +204,7 @@ function Targets ({ className = '', isInElection, nominatedBy, ownStashes, targe
 
   const header = useMemo(() => [
     [t('validators'), 'start', 3],
-    [t('payout'), 'media--1400'],
+    [t('last era payout'), 'media--1400'],
     [t('nominators'), 'media--1200', 2],
     [t('comm.'), 'media--1100'],
     ...(SORT_KEYS as (keyof typeof labelsRef.current)[]).map((header) => [
@@ -313,48 +227,13 @@ function Targets ({ className = '', isInElection, nominatedBy, ownStashes, targe
       >
         <Toggle
           className='staking--buttonToggle'
-          label={t<string>('one validator per operator')}
-          onChange={setToggle.withGroup}
-          value={toggles.withGroup}
-        />
-        <Toggle
-          className='staking--buttonToggle'
-          label={
-            MAX_COMM_PERCENT > 0
-              ? t<string>('comm. <= {{maxComm}}%', { replace: { maxComm: MAX_COMM_PERCENT } })
-              : t<string>('comm. <= median')
-          }
-          onChange={setToggle.withoutComm}
-          value={toggles.withoutComm}
-        />
-        <Toggle
-          className='staking--buttonToggle'
-          label={
-            MAX_CAP_PERCENT < 100
-              ? t<string>('capacity < {{maxCap}}%', { replace: { maxCap: MAX_CAP_PERCENT } })
-              : t<string>('with capacity')
-          }
-          onChange={setToggle.withoutOver}
-          value={toggles.withoutOver}
-        />
-        {api.consts.babe && (
-          // FIXME have some sane era defaults for Aura
-          <Toggle
-            className='staking--buttonToggle'
-            label={t<string>('recent payouts')}
-            onChange={setToggle.withPayout}
-            value={toggles.withPayout}
-          />
-        )}
-        <Toggle
-          className='staking--buttonToggle'
           label={t<string>('currently elected')}
           onChange={setToggle.withElected}
           value={toggles.withElected}
         />
       </Filtering>
     </div>
-  ), [api, nameFilter, _setNameFilter, setToggle, t, toggles]);
+  ), [nameFilter, _setNameFilter, setToggle, t, toggles]);
 
   const displayList = isQueryFiltered
     ? validators

--- a/packages/page-staking/src/useSortedTargets.ts
+++ b/packages/page-staking/src/useSortedTargets.ts
@@ -117,7 +117,7 @@ function sortValidators (list: ValidatorInfo[]): ValidatorInfo[] {
     );
 }
 
-function extractSingle (api: ApiPromise, allAccounts: string[], derive: DeriveStakingElected | DeriveStakingWaiting, favorites: string[], { activeEra, eraLength, lastEra, sessionLength }: LastEra, historyDepth?: BN, withReturns?: boolean): [ValidatorInfo[], Record<string, BN>] {
+function extractSingle (api: ApiPromise, allAccounts: string[], derive: DeriveStakingElected | DeriveStakingWaiting, favorites: string[], { activeEra, lastEra }: LastEra, historyDepth?: BN, withReturns?: boolean): [ValidatorInfo[], Record<string, BN>] {
   const nominators: Record<string, BN> = {};
   const emptyExposure = api.createType('Exposure');
   const earliestEra = historyDepth && lastEra.sub(historyDepth).iadd(BN_ONE);
@@ -173,8 +173,8 @@ function extractSingle (api: ApiPromise, allAccounts: string[], derive: DeriveSt
       key,
       knownLength: activeEra.sub(stakingLedger.claimedRewards[0] || activeEra),
       // only use if it is more recent than historyDepth
-      lastPayout: earliestEra && lastEraPayout && lastEraPayout.gt(earliestEra) && !sessionLength.eq(BN_ONE)
-        ? lastEra.sub(lastEraPayout).mul(eraLength)
+      lastPayout: earliestEra && lastEraPayout && lastEraPayout.gt(earliestEra)
+        ? lastEraPayout
         : undefined,
       minNominated,
       numNominators: (exposure.others || []).length,

--- a/packages/react-hooks/src/useBlockInterval.ts
+++ b/packages/react-hooks/src/useBlockInterval.ts
@@ -14,7 +14,7 @@ import { A_DAY } from './useBlocksPerDays';
 // Some chains incorrectly use these, i.e. it is set to values such as 0 or even 2
 // Use a low minimum validity threshold to check these against
 const THRESHOLD = BN_THOUSAND.div(BN_TWO);
-const DEFAULT_TIME = new BN(6_000);
+const DEFAULT_TIME = new BN(1_000);
 
 function calcInterval (api: ApiPromise): BN {
   return bnMin(A_DAY, (


### PR DESCRIPTION
This PR removes four toggles from Staking/Targets view:
* `one validator per operator` - confusing for the users
* `comm <= 10%` - not required for the AlephZero
* `with capacity` - info about validator over nominated is already expressed in the Overview tab,
* `with payouts` - no required in the AlephZero,

Also, this PR fixes displaying `payout` column and renaming it to `last era payout`

![image](https://user-images.githubusercontent.com/3909333/208399060-303264a4-7382-482a-9a51-8d258f566136.png)
