### PR TITLE
Manually calculate pending pool rewards

### DIFF
--- a/packages/page-staking/src/Actions/Pool/Account.tsx
+++ b/packages/page-staking/src/Actions/Pool/Account.tsx
@@ -8,6 +8,7 @@ import type { SortedTargets } from '../../types';
 
 import React, { useCallback, useContext, useMemo } from 'react';
 
+import useAccountInfoManualRewards from '@polkadot/app-staking/Actions/Pool/useAccountInfoManualRewards';
 import { AddressSmall, Badge, Menu, Popup, StakingRedeemable, StakingUnbonding, StatusContext } from '@polkadot/react-components';
 import { useApi, useToggle } from '@polkadot/react-hooks';
 import { FormatBalance } from '@polkadot/react-query';
@@ -19,7 +20,9 @@ import Nominate from '../Account/Nominate';
 import useSlashingSpans from '../useSlashingSpans';
 import BondExtra from './BondExtra';
 import Unbond from './Unbond';
-import useAccountInfo from './useAccountInfo';
+
+// TODO use pendingRewards API with Substrate >= 9.29
+// import useAccountInfo from './useAccountInfo';
 
 interface Props {
   accountId: string;
@@ -70,7 +73,10 @@ function Pool ({ accountId, className, info: { bonded: { roles }, metadata, nomi
   const [isBondOpen, toggleBond] = useToggle();
   const [isNominateOpen, toggleNominate] = useToggle();
   const [isUnbondOpen, toggleUnbond] = useToggle();
-  const accInfo = useAccountInfo(accountId);
+
+  // TODO use pendingRewards API with Substrate >= 9.29
+  // const accInfo = useAccountInfo(accountId);
+  const accInfo = useAccountInfoManualRewards(accountId, poolId);
 
   const stakingInfo = useMemo(
     () => sessionProgress && accInfo && accInfo.member.unbondingEras && !accInfo.member.unbondingEras.isEmpty

--- a/packages/page-staking/src/Actions/Pool/useAccountInfoManualRewards.ts
+++ b/packages/page-staking/src/Actions/Pool/useAccountInfoManualRewards.ts
@@ -1,0 +1,72 @@
+// Copyright 2017-2022 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Option } from '@polkadot/types';
+import type { PalletNominationPoolsPoolMember } from '@polkadot/types/lookup';
+import type { AccountInfo } from './types';
+
+import { useEffect, useState } from 'react';
+
+import usePoolInfo from '@polkadot/app-staking/Pools/usePoolInfo';
+import { createNamedHook, useApi, useCall, useIsMountedRef } from '@polkadot/react-hooks';
+import { PalletNominationPoolsBondedPoolInner, PalletNominationPoolsRewardPool } from '@polkadot/types/lookup';
+import { BN } from '@polkadot/util';
+
+const OPT_DEL = {
+  transform: (opt: Option<PalletNominationPoolsPoolMember>): PalletNominationPoolsPoolMember | null =>
+    opt.unwrapOr(null)
+};
+
+// as per polkadot-staking-dashboard code
+function calculatePayout (
+  bondedPool: PalletNominationPoolsBondedPoolInner,
+  rewardPool: PalletNominationPoolsRewardPool,
+  member: PalletNominationPoolsPoolMember,
+  rewardAccountBalance: BN
+) {
+  const rewardCounterBase = new BN(10).pow(new BN(18));
+
+  // convert needed values into BNs
+  const totalRewardsClaimed = new BN(rewardPool.totalRewardsClaimed);
+  const lastRecordedTotalPayouts = new BN(rewardPool.lastRecordedTotalPayouts);
+  const memberLastRecordedRewardCounter = new BN(member.lastRecordedRewardCounter);
+  const poolLastRecordedRewardCounter = new BN(rewardPool.lastRecordedRewardCounter);
+  const bondedPoolPoints = new BN(bondedPool.points);
+  const points = new BN(member.points);
+  const rewardPoolBalance = rewardAccountBalance;
+
+  // calculate the current reward counter
+  const payoutsSinceLastRecord = rewardPoolBalance
+    .add(totalRewardsClaimed)
+    .sub(lastRecordedTotalPayouts);
+
+  const currentRewardCounter = (
+    bondedPoolPoints.eq(new BN(0))
+      ? new BN(0)
+      : payoutsSinceLastRecord.mul(rewardCounterBase).div(bondedPoolPoints)
+  ).add(poolLastRecordedRewardCounter);
+
+  const pendingRewards = currentRewardCounter
+    .sub(memberLastRecordedRewardCounter)
+    .mul(points)
+    .div(rewardCounterBase);
+
+  return pendingRewards;
+}
+
+function useAccountInfoManualRewardsImpl (accountId: string, poolId: BN): AccountInfo | null {
+  const { api } = useApi();
+  const isMountedRef = useIsMountedRef();
+  const [state, setState] = useState<AccountInfo | null>(null);
+  const member = useCall(api.query.nominationPools.poolMembers, [accountId], OPT_DEL);
+  const poolInfo = usePoolInfo(poolId);
+
+  useEffect((): void => {
+    member && poolInfo && isMountedRef.current && setState(
+      { claimable: calculatePayout(poolInfo.bonded, poolInfo.reward, member, poolInfo.rewardClaimable), member });
+  }, [accountId, member, poolInfo, isMountedRef]);
+
+  return state;
+}
+
+export default createNamedHook('useAccountInfoManualRewards', useAccountInfoManualRewardsImpl);


### PR DESCRIPTION
This PR is a short term solution, but hopefully the final, fix for displaying claimiable user rewards in Staking/Accounts -> Pooled view. Current version takes it from `nominatioPoolsApi.pendinRewards` that has a bug in Substrate 9.28 that is currently used in AlephZero Testnet & Mainnet. Once >=9.29 is released, we can revert this fix to use runtime API calls to calculate pending rewards. 

Manual calculations done as per https://github.com/Cardinal-Cryptography/polkadot-staking-dashboard/blob/master/src/contexts/Pools/ActivePools/index.tsx#L526-L581

Tested with local net and on Testnet. 