### PR TITLE
A0-2470: Adjust block count by +1 in Staking/Performance tab

### DIFF
--- a/packages/page-staking/src/Query/index.tsx
+++ b/packages/page-staking/src/Query/index.tsx
@@ -49,6 +49,7 @@ function Query ({ className }: Props): React.ReactElement<Props> {
   const pastSessions = useMemo(() => {
     if (currentSession && currentEra && historyDepth && minimumSessionNumber) {
       const maxSessionQueryDepth = 4 * historyDepth;
+
       const minSessionNumber = Math.max(minimumSessionNumber, currentSession - maxSessionQueryDepth);
       const queryDepth = currentSession - minSessionNumber;
 


### PR DESCRIPTION
Per latest polkadot-apps changes, they now return the last session block author correctly. In a previous version of Staking/Performance tab we displayed this information incorrectly as well. This item is to use the last session block author (ie block (n+1)*900 for session n) and adjust +1 block created column. 

This makes sense only for past sessions, as for the current session we display only what is in elections.sessionValidatorBlockCount , and at the moment block (n+1)*900 is forged, we immediately reset the current block count and advance to the next session, so adjustment can’t be seen anyways.