### PR TITLE
A0-2486: WS_URL env value cannot be the same as Aleph Zero Testnet or Aleph Zero endpoints

### DIFF
--- a/packages/apps-config/src/endpoints/development.ts
+++ b/packages/apps-config/src/endpoints/development.ts
@@ -6,39 +6,6 @@ import type { LinkOption } from './types.js';
 
 export const CUSTOM_ENDPOINT_KEY = 'polkadot-app-custom-endpoints';
 
-interface EnvWindow {
-  // eslint-disable-next-line camelcase
-  process_env?: {
-    WS_URL: string;
-  }
-}
-
-export function createCustom (t: TFunction): LinkOption[] {
-  const WS_URL = (
-    (typeof process !== 'undefined' ? process.env?.WS_URL : undefined) ||
-    (typeof window !== 'undefined' ? (window as EnvWindow).process_env?.WS_URL : undefined)
-  );
-
-  return WS_URL
-    ? [
-      {
-        isHeader: true,
-        text: t('rpc.dev.custom', 'Custom environment', { ns: 'apps-config' }),
-        textBy: '',
-        ui: {},
-        value: ''
-      },
-      {
-        info: 'WS_URL',
-        text: t('rpc.dev.custom.entry', 'Custom {{WS_URL}}', { ns: 'apps-config', replace: { WS_URL } }),
-        textBy: WS_URL,
-        ui: {},
-        value: WS_URL
-      }
-    ]
-    : [];
-}
-
 export function createOwn (t: TFunction): LinkOption[] {
   try {
     // this may not be available, e.g. when running via script
@@ -73,6 +40,14 @@ export function createDev (t: TFunction): LinkOption[] {
       textBy: '127.0.0.1:9944',
       ui: {},
       value: 'ws://127.0.0.1:9944'
+    },
+    {
+      dnslink: 'local',
+      info: 'local',
+      text: t('rpc.dev.azero.dev', 'Aleph Zero Devnet', { ns: 'apps-config' }),
+      textBy: 'ws.dev.azero.dev',
+      ui: {},
+      value: 'wss://ws.dev.azero.dev'
     }
   ];
 }

--- a/packages/apps-config/src/endpoints/index.ts
+++ b/packages/apps-config/src/endpoints/index.ts
@@ -4,7 +4,7 @@
 import type { TFunction, TOptions } from '../types.js';
 import type { LinkOption } from './types.js';
 
-import { createCustom, createDev, createOwn } from './development.js';
+import { createDev, createOwn } from './development.js';
 import { prodChains, prodRelayKusama, prodRelayPolkadot } from './production.js';
 import { testChains, testRelayRococo, testRelayWestend } from './testing.js';
 import { expandEndpoints } from './util.js';
@@ -27,7 +27,6 @@ function defaultT (keyOrText: string, text?: string, options?: TOptions): string
 
 export function createWsEndpoints (t: TFunction = defaultT, firstOnly = false, withSort = true): LinkOption[] {
   return [
-    ...createCustom(t),
     {
       isDisabled: false,
       isHeader: true,

--- a/packages/apps/src/initSettings.ts
+++ b/packages/apps/src/initSettings.ts
@@ -48,7 +48,8 @@ function getApiUrl (): string {
   }
 
   const stored = store.get('settings') as Record<string, unknown> || {};
-  const fallbackUrl = endpoints.find(({ value }) => !!value);
+  const fallbackUrl = endpoints.find(({ value }) => value === process.env.WS_URL) ||
+    endpoints.find(({ value }) => !!value);
 
   // via settings, or the default chain
   return [stored.apiUrl, process.env.WS_URL].includes(settings.apiUrl)


### PR DESCRIPTION
After Aleph Wallet 8.0 release, it turned out colors are broken, ie test.azero.dev shown orange, development chain colors instead of Aleph Zero mint branding. This was an issue introduced in a rebase to the latest upstream, which changed the way how colors are loaded. Previously, it was loaded from a static lookup that mapped some ids to colors. 

Now they are read from endpoints, property ui , e.g. https://github.com/Cardinal-Cryptography/apps/blob/alephzero/packages/apps-config/src/endpoints/production.ts#L37  . Now this feature on its own is fine, as it is exactly like it works in the upstream repo. But in combination with our usage on infra side introduced a bug. On Devnet/Testnet/Mainnet, we start Aleph  Wallet with WS_URL env variable pointing out to wss://ws.dev.azero.dev , wss://ws.test.azero.dev ,  and wss://ws.azero.dev respectively.  When WS_URL is used, in the upstream repo and Aleph Wallet version < 8.X, in the top left corner of an endpoint menu there appears “Custom endpoint” widget, filled with value of WS_ENV variable. Since this is the first endpoint on the list, website logic takes it as the default endpoint, so when connected for the first time, it displays the respective Aleph Zero website. When starting a website locally, we don’t use WS_URL . All the above explains why the issue was caught only in Testnet. 

The original issue can be fixed in the upstream repo, which will be the scope of this item to raise. The problem is that endpoints are searched by value property, and if we add a WS_URL that points to wss://ws.test.azero.dev , another element in the array with the same exists. The first such element does not have ui ,  and the second does have, but only the first one is chosen as it appears first on the list. Hence, fix on our fork would be to remove custom endpoints logic, and leave WS_URL semantics only to be a default endpoint for a website to connect to.

This change adds as well Aleph Zero Devnet to endpoints, under Development.