### PR TITLE
A0-2596 Enable local storage mode by default

### DIFF
--- a/packages/page-accounts/src/Accounts/index.tsx
+++ b/packages/page-accounts/src/Accounts/index.tsx
@@ -90,9 +90,9 @@ function groupAccounts (accounts: SortedAccount[]): Record<GroupName, string[]> 
 // this is a workaround to not fork https://github.com/polkadot-js/ui/tree/master/packages/ui-settings
 // below value is the default one https://github.com/polkadot-js/ui/blob/master/packages/ui-settings/src/defaults/index.ts#L59
 export const StorageMode = {
-    disabled: 'on',
-    enabled: 'off'
-  }
+  disabled: 'on',
+  enabled: 'off'
+};
 
 function Overview ({ className = '', onStatusChange }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();

--- a/packages/page-accounts/src/Accounts/index.tsx
+++ b/packages/page-accounts/src/Accounts/index.tsx
@@ -87,6 +87,15 @@ function groupAccounts (accounts: SortedAccount[]): Record<GroupName, string[]> 
   return ret;
 }
 
+export function getStorageMode() {
+  // this is a workaround to not fork https://github.com/polkadot-js/ui/tree/master/packages/ui-settings
+  // below value is the default one https://github.com/polkadot-js/ui/blob/master/packages/ui-settings/src/defaults/index.ts#L59
+  return {
+    enabled: 'off',
+    disabled: 'on',
+  };
+}
+
 function Overview ({ className = '', onStatusChange }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const { api, isElectron } = useApi();
@@ -144,7 +153,7 @@ function Overview ({ className = '', onStatusChange }: Props): React.ReactElemen
   );
 
   const canStoreAccounts = useMemo(
-    () => isElectron || (!isIpfs && settings.get().storage === 'on'),
+    () => isElectron || (!isIpfs && settings.get().storage === getStorageMode().enabled),
     [isElectron, isIpfs]
   );
 

--- a/packages/page-accounts/src/Accounts/index.tsx
+++ b/packages/page-accounts/src/Accounts/index.tsx
@@ -151,7 +151,7 @@ function Overview ({ className = '', onStatusChange }: Props): React.ReactElemen
   );
 
   const canStoreAccounts = useMemo(
-    () => isElectron || (!isIpfs && settings.get().storage === getStorageMode().enabled),
+    () => isElectron || (!isIpfs && settings.get().storage === StorageMode.enabled),
     [isElectron, isIpfs]
   );
 

--- a/packages/page-accounts/src/Accounts/index.tsx
+++ b/packages/page-accounts/src/Accounts/index.tsx
@@ -87,14 +87,12 @@ function groupAccounts (accounts: SortedAccount[]): Record<GroupName, string[]> 
   return ret;
 }
 
-export function getStorageMode (): {enabled: string, disabled: string} {
-  // this is a workaround to not fork https://github.com/polkadot-js/ui/tree/master/packages/ui-settings
-  // below value is the default one https://github.com/polkadot-js/ui/blob/master/packages/ui-settings/src/defaults/index.ts#L59
-  return {
+// this is a workaround to not fork https://github.com/polkadot-js/ui/tree/master/packages/ui-settings
+// below value is the default one https://github.com/polkadot-js/ui/blob/master/packages/ui-settings/src/defaults/index.ts#L59
+export const StorageMode = {
     disabled: 'on',
     enabled: 'off'
-  };
-}
+  }
 
 function Overview ({ className = '', onStatusChange }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();

--- a/packages/page-accounts/src/Accounts/index.tsx
+++ b/packages/page-accounts/src/Accounts/index.tsx
@@ -87,12 +87,12 @@ function groupAccounts (accounts: SortedAccount[]): Record<GroupName, string[]> 
   return ret;
 }
 
-export function getStorageMode() {
+export function getStorageMode (): {enabled: string, disabled: string} {
   // this is a workaround to not fork https://github.com/polkadot-js/ui/tree/master/packages/ui-settings
   // below value is the default one https://github.com/polkadot-js/ui/blob/master/packages/ui-settings/src/defaults/index.ts#L59
   return {
-    enabled: 'off',
     disabled: 'on',
+    enabled: 'off'
   };
 }
 

--- a/packages/page-accounts/test/pages/accountsPage.tsx
+++ b/packages/page-accounts/test/pages/accountsPage.tsx
@@ -12,13 +12,13 @@ import { Sidebar } from '@polkadot/test-support/pagesElements';
 import { assertText, clickButton } from '@polkadot/test-support/utils';
 import { settings } from '@polkadot/ui-settings';
 
-import AccountOverview from '../../src/Accounts/index.js';
+import AccountOverview, {getStorageMode} from '../../src/Accounts/index.js';
 import { AccountRow } from '../pageElements/AccountRow.js';
 
 const NOOP_CHANGE = () => undefined;
 
 // set the account creation for localStorage to on
-settings.set({ ...settings.get(), storage: 'on' });
+settings.set({ ...settings.get(), storage: getStorageMode().enabled });
 
 export class AccountsPage extends Page {
   constructor () {

--- a/packages/page-accounts/test/pages/accountsPage.tsx
+++ b/packages/page-accounts/test/pages/accountsPage.tsx
@@ -12,7 +12,7 @@ import { Sidebar } from '@polkadot/test-support/pagesElements';
 import { assertText, clickButton } from '@polkadot/test-support/utils';
 import { settings } from '@polkadot/ui-settings';
 
-import AccountOverview, {getStorageMode} from '../../src/Accounts/index.js';
+import AccountOverview, { getStorageMode } from '../../src/Accounts/index.js';
 import { AccountRow } from '../pageElements/AccountRow.js';
 
 const NOOP_CHANGE = () => undefined;

--- a/packages/page-accounts/test/pages/accountsPage.tsx
+++ b/packages/page-accounts/test/pages/accountsPage.tsx
@@ -12,13 +12,13 @@ import { Sidebar } from '@polkadot/test-support/pagesElements';
 import { assertText, clickButton } from '@polkadot/test-support/utils';
 import { settings } from '@polkadot/ui-settings';
 
-import AccountOverview, { getStorageMode } from '../../src/Accounts/index.js';
+import AccountOverview, { StorageMode } from '../../src/Accounts/index.js';
 import { AccountRow } from '../pageElements/AccountRow.js';
 
 const NOOP_CHANGE = () => undefined;
 
 // set the account creation for localStorage to on
-settings.set({ ...settings.get(), storage: getStorageMode().enabled });
+settings.set({ ...settings.get(), storage: StorageMode.enabled });
 
 export class AccountsPage extends Page {
   constructor () {

--- a/packages/page-settings/src/General.tsx
+++ b/packages/page-settings/src/General.tsx
@@ -12,7 +12,7 @@ import { Button, Dropdown, MarkWarning } from '@polkadot/react-components';
 import { useApi, useIpfs, useLedger } from '@polkadot/react-hooks';
 import { settings } from '@polkadot/ui-settings';
 
-import { getStorageMode } from '../../page-accounts/src/Accounts/index.js';
+import { StorageMode } from '../../page-accounts/src/Accounts/index.js';
 import { useTranslation } from './translate.js';
 import { createIdenticon, createOption, save, saveAndReload } from './util.js';
 
@@ -67,8 +67,8 @@ function General ({ className = '' }: Props): React.ReactElement<Props> {
 
   const storageOptions = useMemo(
     () => [
-      { text: t<string>('Allow local in-browser account storage'), value: getStorageMode().enabled },
-      { text: t<string>('Do not allow local in-browser account storage'), value: getStorageMode().disabled }
+      { text: t<string>('Allow local in-browser account storage'), value: StorageMode.enabled },
+      { text: t<string>('Do not allow local in-browser account storage'), value: StorageMode.disabled }
     ],
     [t]
   );
@@ -163,7 +163,7 @@ function General ({ className = '' }: Props): React.ReactElement<Props> {
               options={storageOptions}
             />
           </div>
-          {state.storage === getStorageMode().enabled && (
+          {state.storage === StorageMode.enabled && (
             <div className='ui--row'>
               <MarkWarning content={t<string>('It is recommended that you store all keys externally to the in-page browser local storage, either on browser extensions, signers operating via QR codes or hardware devices. This option is provided for advanced users with strong backup policies.')} />
             </div>

--- a/packages/page-settings/src/General.tsx
+++ b/packages/page-settings/src/General.tsx
@@ -163,7 +163,7 @@ function General ({ className = '' }: Props): React.ReactElement<Props> {
               options={storageOptions}
             />
           </div>
-          {state.storage ===  getStorageMode().enabled && (
+          {state.storage === getStorageMode().enabled && (
             <div className='ui--row'>
               <MarkWarning content={t<string>('It is recommended that you store all keys externally to the in-page browser local storage, either on browser extensions, signers operating via QR codes or hardware devices. This option is provided for advanced users with strong backup policies.')} />
             </div>

--- a/packages/page-settings/src/General.tsx
+++ b/packages/page-settings/src/General.tsx
@@ -14,6 +14,7 @@ import { settings } from '@polkadot/ui-settings';
 
 import { useTranslation } from './translate.js';
 import { createIdenticon, createOption, save, saveAndReload } from './util.js';
+import {getStorageMode} from "../../page-accounts/src/Accounts/index";
 
 interface Props {
   className?: string;
@@ -66,8 +67,8 @@ function General ({ className = '' }: Props): React.ReactElement<Props> {
 
   const storageOptions = useMemo(
     () => [
-      { text: t<string>('Allow local in-browser account storage'), value: 'on' },
-      { text: t<string>('Do not allow local in-browser account storage'), value: 'off' }
+      { text: t<string>('Allow local in-browser account storage'), value: getStorageMode().enabled },
+      { text: t<string>('Do not allow local in-browser account storage'), value: getStorageMode().disabled }
     ],
     [t]
   );
@@ -162,7 +163,7 @@ function General ({ className = '' }: Props): React.ReactElement<Props> {
               options={storageOptions}
             />
           </div>
-          {state.storage === 'on' && (
+          {state.storage === 'off' && (
             <div className='ui--row'>
               <MarkWarning content={t<string>('It is recommended that you store all keys externally to the in-page browser local storage, either on browser extensions, signers operating via QR codes or hardware devices. This option is provided for advanced users with strong backup policies.')} />
             </div>

--- a/packages/page-settings/src/General.tsx
+++ b/packages/page-settings/src/General.tsx
@@ -12,9 +12,9 @@ import { Button, Dropdown, MarkWarning } from '@polkadot/react-components';
 import { useApi, useIpfs, useLedger } from '@polkadot/react-hooks';
 import { settings } from '@polkadot/ui-settings';
 
+import { getStorageMode } from '../../page-accounts/src/Accounts/index.js';
 import { useTranslation } from './translate.js';
 import { createIdenticon, createOption, save, saveAndReload } from './util.js';
-import {getStorageMode} from "../../page-accounts/src/Accounts/index";
 
 interface Props {
   className?: string;
@@ -163,7 +163,7 @@ function General ({ className = '' }: Props): React.ReactElement<Props> {
               options={storageOptions}
             />
           </div>
-          {state.storage === 'off' && (
+          {state.storage ===  getStorageMode().enabled && (
             <div className='ui--row'>
               <MarkWarning content={t<string>('It is recommended that you store all keys externally to the in-page browser local storage, either on browser extensions, signers operating via QR codes or hardware devices. This option is provided for advanced users with strong backup policies.')} />
             </div>


### PR DESCRIPTION
This is a bit of a hacky implementation that enables storing local accounts by default. It can be modified by the below setting in Settings -> General:

![image](https://github.com/Cardinal-Cryptography/apps/assets/3909333/5e166f69-7455-4e6b-aefd-db038a22d240)

Non-hacky implementation implies forking one repo in our org, which is more work imho.