### PR TITLE
A0-2596: Migrated storing local account to on by default

### DIFF
--- a/packages/apps/src/initSettings.ts
+++ b/packages/apps/src/initSettings.ts
@@ -76,11 +76,10 @@ function getApiUrl (): string {
 }
 
 function migrateStoringAccountStorage () {
-  const localStorageStoragingVersion = store.get('localStorageVersion') as number || 0;
+  const localStorageVersion = store.get('localStorageVersion', 0) as unknown;
 
-  if (localStorageStoragingVersion === 0) {
-    console.info('Setting storing local accounts to on');
-    settings.set({ ...settings.get(), storage: StorageMode.enabled });
+  if (localStorageVersion === 0) {
+    settings.set({ storage: StorageMode.enabled });
     store.set('localStorageVersion', 1);
   }
 }

--- a/packages/apps/src/initSettings.ts
+++ b/packages/apps/src/initSettings.ts
@@ -9,6 +9,11 @@ import { extractIpfsDetails } from '@polkadot/react-hooks/useIpfs';
 import { settings } from '@polkadot/ui-settings';
 import { assert } from '@polkadot/util';
 
+export const StorageMode = {
+  disabled: 'off',
+  enabled: 'on'
+};
+
 function networkOrUrl (apiUrl: string): void {
   if (apiUrl.startsWith('light://')) {
     console.log('Light endpoint=', apiUrl.replace('light://', ''));
@@ -70,6 +75,16 @@ function getApiUrl (): string {
       : 'ws://127.0.0.1:9944'; // nothing found, go local
 }
 
+function migrateStoringAccountStorage () {
+  const localStorageStoragingVersion = store.get('localStorageVersion') as number || 0;
+
+  if (localStorageStoragingVersion === 0) {
+    console.info('Setting storing local accounts to on');
+    settings.set({ ...settings.get(), storage: StorageMode.enabled });
+    store.set('localStorageVersion', 1);
+  }
+}
+
 // There cannot be a Substrate Connect light client default (expect only jrpc EndpointType)
 const apiUrl = getApiUrl();
 
@@ -77,3 +92,5 @@ const apiUrl = getApiUrl();
 settings.set({ apiUrl });
 
 networkOrUrl(apiUrl);
+
+migrateStoringAccountStorage();

--- a/packages/page-accounts/src/Accounts/index.tsx
+++ b/packages/page-accounts/src/Accounts/index.tsx
@@ -16,6 +16,7 @@ import { keyring } from '@polkadot/ui-keyring';
 import { settings } from '@polkadot/ui-settings';
 import { BN_ZERO, isFunction } from '@polkadot/util';
 
+import { StorageMode } from '../../../apps/src/initSettings.js';
 import CreateModal from '../modals/Create.js';
 import ImportModal from '../modals/Import.js';
 import Ledger from '../modals/Ledger.js';
@@ -86,13 +87,6 @@ function groupAccounts (accounts: SortedAccount[]): Record<GroupName, string[]> 
 
   return ret;
 }
-
-// this is a workaround to not fork https://github.com/polkadot-js/ui/tree/master/packages/ui-settings
-// below value is the default one https://github.com/polkadot-js/ui/blob/master/packages/ui-settings/src/defaults/index.ts#L59
-export const StorageMode = {
-  disabled: 'on',
-  enabled: 'off'
-};
 
 function Overview ({ className = '', onStatusChange }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();

--- a/packages/page-accounts/test/pages/accountsPage.tsx
+++ b/packages/page-accounts/test/pages/accountsPage.tsx
@@ -12,7 +12,8 @@ import { Sidebar } from '@polkadot/test-support/pagesElements';
 import { assertText, clickButton } from '@polkadot/test-support/utils';
 import { settings } from '@polkadot/ui-settings';
 
-import AccountOverview, { StorageMode } from '../../src/Accounts/index.js';
+import { StorageMode } from '../../../apps/src/initSettings.js';
+import AccountOverview from '../../src/Accounts/index.js';
 import { AccountRow } from '../pageElements/AccountRow.js';
 
 const NOOP_CHANGE = () => undefined;

--- a/packages/page-settings/src/General.tsx
+++ b/packages/page-settings/src/General.tsx
@@ -12,7 +12,7 @@ import { Button, Dropdown, MarkWarning } from '@polkadot/react-components';
 import { useApi, useIpfs, useLedger } from '@polkadot/react-hooks';
 import { settings } from '@polkadot/ui-settings';
 
-import { StorageMode } from '../../page-accounts/src/Accounts/index.js';
+import { StorageMode } from '../../apps/src/initSettings.js';
 import { useTranslation } from './translate.js';
 import { createIdenticon, createOption, save, saveAndReload } from './util.js';
 


### PR DESCRIPTION
This PR is a better version of [previous](https://github.com/Cardinal-Cryptography/apps/commit/07a2cbe02f37495a3e60ab03a06278acbd66ecfb) fix and uses schema versioning technique to achieve the goal to set local storage to `on` only when a user upgrades version to >= 8.X, and only once. 

Unfortunately this does not work backwards, ie if we downgrade the wallet to < 8.X and then upgrade again, this feature does not apply since key `localStorageVersion` will be in local storage anyway. This cannot be fixed without modifying `ui` repo , as `settings` cannot be saved with an additional key that is not in the `SettingsStruct`. 