### PR TITLE
A0-2325: Support `getBlockAuthor` RPC

### DIFF
--- a/packages/apps-config/src/api/spec/aleph-zero.ts
+++ b/packages/apps-config/src/api/spec/aleph-zero.ts
@@ -21,12 +21,10 @@ export default {
           }
         ],
         type: 'Null'
-      }
-    },
-    chain: {
+      },
       getBlockAuthor: {
         description: 'Get the author of the block with given hash.',
-        params:[
+        params: [
           {
             name: 'hash',
             type: 'BlockHash'

--- a/packages/apps-config/src/api/spec/aleph-zero.ts
+++ b/packages/apps-config/src/api/spec/aleph-zero.ts
@@ -22,6 +22,18 @@ export default {
         ],
         type: 'Null'
       }
+    },
+    chain: {
+      getBlockAuthor: {
+        description: 'Get the author of the block with given hash.',
+        params:[
+          {
+            name: 'hash',
+            type: 'BlockHash'
+          }
+        ],
+        type: 'Option<AccountId>'
+      }
     }
   }
 };

--- a/packages/apps-config/src/api/typesBundle.ts
+++ b/packages/apps-config/src/api/typesBundle.ts
@@ -32617,30 +32617,6 @@ export const typesBundle = {
         }
       }
     },
-    "aleph-node": {
-      "rpc": {
-        "alephNode": {
-          "emergencyFinalize": {
-            "description": "Finalize the block with given hash and number using attached signature. Returns the empty string or an error.",
-            "params": [
-              {
-                "name": "justification",
-                "type": "Bytes"
-              },
-              {
-                "name": "hash",
-                "type": "BlockHash"
-              },
-              {
-                "name": "number",
-                "type": "BlockNumber"
-              }
-            ],
-            "type": "Null"
-          }
-        }
-      }
-    },
     "mandala": {
       "rpc": {
         "oracle": {
@@ -42820,6 +42796,42 @@ export const typesBundle = {
           }
         }
       ]
+    },
+    "aleph-node": {
+      "rpc": {
+        "alephNode": {
+          "emergencyFinalize": {
+            "description": "Finalize the block with given hash and number using attached signature. Returns the empty string or an error.",
+            "params": [
+              {
+                "name": "justification",
+                "type": "Bytes"
+              },
+              {
+                "name": "hash",
+                "type": "BlockHash"
+              },
+              {
+                "name": "number",
+                "type": "BlockNumber"
+              }
+            ],
+            "type": "Null"
+          }
+        },
+        "chain": {
+          "getBlockAuthor": {
+            "description": "Get the author of the block with given hash.",
+            "params": [
+              {
+                "name": "hash",
+                "type": "BlockHash"
+              }
+            ],
+            "type": "Option<AccountId>"
+          }
+        }
+      }
     },
     "altair": {
       "types": [

--- a/packages/apps-config/src/api/typesBundle.ts
+++ b/packages/apps-config/src/api/typesBundle.ts
@@ -42817,9 +42817,7 @@ export const typesBundle = {
               }
             ],
             "type": "Null"
-          }
-        },
-        "chain": {
+          },
           "getBlockAuthor": {
             "description": "Get the author of the block with given hash.",
             "params": [


### PR DESCRIPTION
We add support for `alephNode_getBlockAuthor` RPC call.

![image](https://github.com/Cardinal-Cryptography/apps/assets/27450471/3a630acb-6f6b-4eb6-90b8-369add79c99c)
