### PR TITLE
A0-2682: Expose runtime API

### DIFF
--- a/packages/apps-config/src/api/spec/aleph-zero.ts
+++ b/packages/apps-config/src/api/spec/aleph-zero.ts
@@ -1,6 +1,9 @@
 // Copyright 2017-2023 @polkadot/apps-config authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// Structs and enum variants need to be in order
+/* eslint-disable sort-keys */
+
 export default {
   rpc: {
     alephNode: {
@@ -34,61 +37,93 @@ export default {
       }
     }
   },
+  runtime: {
+    AlephSessionApi: [
+      {
+        methods: {
+          authorities: {
+            description: '',
+            params: [],
+            type: 'Vec<AuthorityId>'
+          },
+          authority_data: {
+            description: '',
+            params: [],
+            type: 'SessionAuthorityData'
+          },
+          finality_version: {
+            description: '',
+            params: [],
+            type: 'Version'
+          },
+          millisecs_per_block: {
+            description: '',
+            params: [],
+            type: 'u64'
+          },
+          next_session_authorities: {
+            description: '',
+            params: [],
+            type: 'Result<Vec<AuthorityId>, ApiError>'
+          },
+          next_session_authority_data: {
+            description: '',
+            params: [],
+            type: 'Result<SessionAuthorityData, ApiError>'
+          },
+          next_session_finality_version: {
+            description: '',
+            params: [],
+            type: 'Version'
+          },
+          predict_session_committee: {
+            description: '',
+            params: [
+              {
+                name: 'session',
+                type: 'SessionIndex'
+              }
+            ],
+            type: 'Result<SessionCommittee, SessionValidatorError>'
+          },
+          session_period: {
+            description: '',
+            params: [],
+            type: 'u32'
+          }
+        },
+        version: 1
+      }
+    ]
+  },
   types: [
     {
       // supported on all versions
       minmax: [0, undefined],
       types: {
         ApiError: {
-          '_enum': ['DecodeKey']
+          _enum: ['DecodeKey']
         },
         SessionAuthorityData: {
           authorities: 'Vec<AuthorityId>',
-          emergency_finalizer: 'Option<AuthorityId>',
+          emergency_finalizer: 'Option<AuthorityId>'
+        },
+        SessionCommittee: {
+          finality_committee: 'Vec<AccountId>',
+          block_producers: 'Vec<AccountId>'
+        },
+        SessionNotWithinRangeError: {
+          lower_limit: 'SessionIndex',
+          upper_limit: 'SessionIndex'
+        },
+        SessionValidatorError: {
+          _enum: {
+            SessionNotWithinRange: 'SessionNotWithinRangeError',
+            Other: 'Vec<u8>'
+          }
         },
         Version: 'u32'
       }
     }
-  ],
-  runtime: {
-    AlephSessionApi: [
-      {
-        version: 1,
-        methods: {
-          next_session_authorities: {
-            params: [],
-            type: 'Result<Vec<AuthorityId>, ApiError>'
-          },
-          authorities: {
-            params: [],
-            type: 'Vec<AuthorityId>'
-          },
-          next_session_authority_data: {
-            params: [],
-            type: 'Result<SessionAuthorityData, ApiError>'
-          },
-          authority_data: {
-            params: [],
-            type: 'SessionAuthorityData'
-          },
-          session_period: {
-            params: [],
-            type: 'u32'
-          },
-          millisecs_per_block: {
-            params: [],
-            type: 'u64'
-          },
-          finality_version: {
-            params: [],
-            type: 'Version'
-          },
-          next_session_finality_version: {
-            params: [],
-            type: 'Version'
-          },
-        }
-      }
-    ]
-  }
+  ]
 };

--- a/packages/apps-config/src/api/spec/aleph-zero.ts
+++ b/packages/apps-config/src/api/spec/aleph-zero.ts
@@ -33,5 +33,62 @@ export default {
         type: 'Option<AccountId>'
       }
     }
+  },
+  types: [
+    {
+      // supported on all versions
+      minmax: [0, undefined],
+      types: {
+        ApiError: {
+          '_enum': ['DecodeKey']
+        },
+        SessionAuthorityData: {
+          authorities: 'Vec<AuthorityId>',
+          emergency_finalizer: 'Option<AuthorityId>',
+        },
+        Version: 'u32'
+      }
+    }
+  ],
+  runtime: {
+    AlephSessionApi: [
+      {
+        version: 1,
+        methods: {
+          next_session_authorities: {
+            params: [],
+            type: 'Result<Vec<AuthorityId>, ApiError>'
+          },
+          authorities: {
+            params: [],
+            type: 'Vec<AuthorityId>'
+          },
+          next_session_authority_data: {
+            params: [],
+            type: 'Result<SessionAuthorityData, ApiError>'
+          },
+          authority_data: {
+            params: [],
+            type: 'SessionAuthorityData'
+          },
+          session_period: {
+            params: [],
+            type: 'u32'
+          },
+          millisecs_per_block: {
+            params: [],
+            type: 'u64'
+          },
+          finality_version: {
+            params: [],
+            type: 'Version'
+          },
+          next_session_finality_version: {
+            params: [],
+            type: 'Version'
+          },
+        }
+      }
+    ]
   }
 };

--- a/packages/apps-config/src/api/typesBundle.ts
+++ b/packages/apps-config/src/api/typesBundle.ts
@@ -42829,6 +42829,67 @@ export const typesBundle = {
             "type": "Option<AccountId>"
           }
         }
+      },
+      "types": [
+        {
+          "minmax": [
+            0,
+            null
+          ],
+          "types": {
+            "ApiError": {
+              "_enum": [
+                "DecodeKey"
+              ]
+            },
+            "SessionAuthorityData": {
+              "authorities": "Vec<AuthorityId>",
+              "emergency_finalizer": "Option<AuthorityId>"
+            },
+            "Version": "u32"
+          }
+        }
+      ],
+      "runtime": {
+        "AlephSessionApi": [
+          {
+            "version": 1,
+            "methods": {
+              "next_session_authorities": {
+                "params": [],
+                "type": "Result<Vec<AuthorityId>, ApiError>"
+              },
+              "authorities": {
+                "params": [],
+                "type": "Vec<AuthorityId>"
+              },
+              "next_session_authority_data": {
+                "params": [],
+                "type": "Result<SessionAuthorityData, ApiError>"
+              },
+              "authority_data": {
+                "params": [],
+                "type": "SessionAuthorityData"
+              },
+              "session_period": {
+                "params": [],
+                "type": "u32"
+              },
+              "millisecs_per_block": {
+                "params": [],
+                "type": "u64"
+              },
+              "finality_version": {
+                "params": [],
+                "type": "Version"
+              },
+              "next_session_finality_version": {
+                "params": [],
+                "type": "Version"
+              }
+            }
+          }
+        ]
       }
     },
     "altair": {

--- a/packages/apps-config/src/api/typesBundle.ts
+++ b/packages/apps-config/src/api/typesBundle.ts
@@ -42830,6 +42830,65 @@ export const typesBundle = {
           }
         }
       },
+      "runtime": {
+        "AlephSessionApi": [
+          {
+            "methods": {
+              "authorities": {
+                "description": "",
+                "params": [],
+                "type": "Vec<AuthorityId>"
+              },
+              "authority_data": {
+                "description": "",
+                "params": [],
+                "type": "SessionAuthorityData"
+              },
+              "finality_version": {
+                "description": "",
+                "params": [],
+                "type": "Version"
+              },
+              "millisecs_per_block": {
+                "description": "",
+                "params": [],
+                "type": "u64"
+              },
+              "next_session_authorities": {
+                "description": "",
+                "params": [],
+                "type": "Result<Vec<AuthorityId>, ApiError>"
+              },
+              "next_session_authority_data": {
+                "description": "",
+                "params": [],
+                "type": "Result<SessionAuthorityData, ApiError>"
+              },
+              "next_session_finality_version": {
+                "description": "",
+                "params": [],
+                "type": "Version"
+              },
+              "predict_session_committee": {
+                "description": "",
+                "params": [
+                  {
+                    "name": "session",
+                    "type": "SessionIndex"
+                  }
+                ],
+                "type": "Result<SessionCommittee, SessionValidatorError>"
+              },
+              "session_period": {
+                "description": "",
+                "params": [],
+                "type": "u32"
+              }
+            },
+            "version": 1
+          }
+        ]
+      },
       "types": [
         {
           "minmax": [
@@ -42846,51 +42905,24 @@ export const typesBundle = {
               "authorities": "Vec<AuthorityId>",
               "emergency_finalizer": "Option<AuthorityId>"
             },
+            "SessionCommittee": {
+              "finality_committee": "Vec<AccountId>",
+              "block_producers": "Vec<AccountId>"
+            },
+            "SessionNotWithinRangeError": {
+              "lower_limit": "SessionIndex",
+              "upper_limit": "SessionIndex"
+            },
+            "SessionValidatorError": {
+              "_enum": {
+                "SessionNotWithinRange": "SessionNotWithinRangeError",
+                "Other": "Vec<u8>"
+              }
+            },
             "Version": "u32"
           }
         }
-      ],
-      "runtime": {
-        "AlephSessionApi": [
-          {
-            "version": 1,
-            "methods": {
-              "next_session_authorities": {
-                "params": [],
-                "type": "Result<Vec<AuthorityId>, ApiError>"
-              },
-              "authorities": {
-                "params": [],
-                "type": "Vec<AuthorityId>"
-              },
-              "next_session_authority_data": {
-                "params": [],
-                "type": "Result<SessionAuthorityData, ApiError>"
-              },
-              "authority_data": {
-                "params": [],
-                "type": "SessionAuthorityData"
-              },
-              "session_period": {
-                "params": [],
-                "type": "u32"
-              },
-              "millisecs_per_block": {
-                "params": [],
-                "type": "u64"
-              },
-              "finality_version": {
-                "params": [],
-                "type": "Version"
-              },
-              "next_session_finality_version": {
-                "params": [],
-                "type": "Version"
-              }
-            }
-          }
-        ]
-      }
+      ]
     },
     "altair": {
       "types": [


### PR DESCRIPTION
Support for aleph-specific Runtime API:

![image](https://github.com/Cardinal-Cryptography/apps/assets/27450471/25395a12-658d-48e6-90db-783149db16ae)
