### PR TITLE
A0-4298: Fix redirection to contracts-ui in azero-dev

### DIFF
--- a/packages/apps-routing/src/contracts.ts
+++ b/packages/apps-routing/src/contracts.ts
@@ -20,7 +20,7 @@ function needsApiCheck (api: ApiPromise): boolean {
 }
 
 export default function create (t: TFunction): Route {
-  let href = 'https://contracts-ui.substrate.io/';
+  let href = 'https://ui.use.ink/';
   const websocket = settings.get().apiUrl;
 
   if (websocket.length > 0) {


### PR DESCRIPTION
When choosing Developers → Contracts tab, it needs to redirect to [https://ui.use.ink/?rpc](https://ui.use.ink/?rpc=wss://ws.azero.dev)=<WS_URL> instead of current https://contracts-ui.substrate.io/?rpc=<WS_URL>.