### PR TITLE
Deduplicate session.validators

### DIFF
--- a/packages/page-staking/src/FutureCommittee/FutureValidators.tsx
+++ b/packages/page-staking/src/FutureCommittee/FutureValidators.tsx
@@ -1,17 +1,16 @@
 // Copyright 2017-2025 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Codec } from '@polkadot/types/types';
-
 import React, { useMemo, useRef, useState } from 'react';
 
 import { Table } from '@polkadot/react-components';
-import { useApi, useCall } from '@polkadot/react-hooks';
+import { useApi } from '@polkadot/react-hooks';
 
 import Filtering from '../Filtering.js';
 import { useEraValidators } from '../Performance/useEraValidators.js';
 import useFutureSessionCommittee from '../Performance/useFutureSessionCommittee.js';
 import { useTranslation } from '../translate.js';
+import useSessionValidators from '../useSessionValidators.js';
 import Address from './Address/index.js';
 
 interface Props {
@@ -35,10 +34,7 @@ function FutureValidators ({ currentSession, maximumSessionNumber }: Props): Rea
 
   const [nameFilter, setNameFilter] = useState<string>('');
 
-  const sessionValidators = useCall<Codec[]>(api.query.session.validators);
-  const sessionValidatorsStrings = useMemo(() => {
-    return sessionValidators?.map((validator) => validator.toString());
-  }, [sessionValidators]);
+  const sessionValidators = useSessionValidators(api);
 
   const eraValidatorsAddresses = useEraValidators(currentSession);
   const eraValidators = useMemo(() => {
@@ -60,7 +56,7 @@ function FutureValidators ({ currentSession, maximumSessionNumber }: Props): Rea
   const futureSessionCommittee = useFutureSessionCommittee(futureSessions ?? []);
 
   const validatorsList: ListEntry[] = useMemo(() => {
-    if (futureSessionCommittee.length > 0 && sessionValidatorsStrings && sessionValidatorsStrings.length > 0) {
+    if (futureSessionCommittee.length > 0 && sessionValidators && sessionValidators.length > 0) {
       return eraValidators.map((accountId) => {
         const nextCommittee = futureSessionCommittee.find((futureCommittee) => {
           return futureCommittee.producers.find((producer) => producer === accountId) !== undefined;
@@ -68,7 +64,7 @@ function FutureValidators ({ currentSession, maximumSessionNumber }: Props): Rea
 
         return {
           accountId,
-          currentSessionCommittee: sessionValidatorsStrings.includes(accountId),
+          currentSessionCommittee: sessionValidators.includes(accountId),
           nextSessionInCommittee: nextCommittee?.session
         };
       }).sort((_, b) => {
@@ -77,7 +73,7 @@ function FutureValidators ({ currentSession, maximumSessionNumber }: Props): Rea
     }
 
     return [];
-  }, [futureSessionCommittee, eraValidators, sessionValidatorsStrings]);
+  }, [futureSessionCommittee, eraValidators, sessionValidators]);
 
   const headerRef = useRef<[string, string, number?][]>(
     [

--- a/packages/page-staking/src/Performance/Performance.tsx
+++ b/packages/page-staking/src/Performance/Performance.tsx
@@ -9,8 +9,9 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import { getCommitteeManagement } from '@polkadot/react-api/getCommitteeManagement';
 import { styled } from '@polkadot/react-components';
-import { useApi, useCall } from '@polkadot/react-hooks';
+import { useApi } from '@polkadot/react-hooks';
 
+import useSessionValidators from '../useSessionValidators.js';
 import ActionsBanner from './ActionsBanner.js';
 import BlockProductionCommitteeList from './BlockProductionCommitteeList.js';
 import Summary from './Summary.js';
@@ -26,19 +27,15 @@ function Performance (): React.ReactElement<null> {
 
   const [sessionValidatorBlockCountLookup, setSessionValidatorBlockCountLookup] = useState<[string, number][]>([]);
   const [expectedBlockCountInSessions, setExpectedBlockCountInSessions] = useState<number | undefined>(undefined);
-  const sessionValidators = useCall<Codec[]>(api.query.session.validators);
-
-  const sessionValidatorsStrings = useMemo(() => {
-    return sessionValidators?.map((validator) => validator.toString());
-  }, [sessionValidators]);
+  const sessionValidators = useSessionValidators(api);
 
   const eraValidatorPerformances: EraValidatorPerformance[] = useMemo(() => {
-    if (!sessionValidatorsStrings) {
+    if (!sessionValidators || sessionValidators.length === 0) {
       return [];
     }
 
     const validatorPerformancesCommittee =
-      sessionValidatorsStrings.map((validator) => {
+      sessionValidators.map((validator) => {
         const maybeBlockCount = sessionValidatorBlockCountLookup.find((elem) => elem[0] === validator);
 
         return {
@@ -52,11 +49,11 @@ function Performance (): React.ReactElement<null> {
 
     const sessionPeriod = Number(getCommitteeManagement(api).consts.sessionPeriod.toString());
 
-    setExpectedBlockCountInSessions(sessionPeriod / sessionValidatorsStrings.length);
+    setExpectedBlockCountInSessions(sessionPeriod / sessionValidators.length);
 
     return validatorPerformancesCommittee;
   },
-  [api, sessionValidatorBlockCountLookup, sessionValidatorsStrings]
+  [api, sessionValidatorBlockCountLookup, sessionValidators]
 
   );
 

--- a/packages/page-staking/src/Performance/useCommitteePerformance.tsx
+++ b/packages/page-staking/src/Performance/useCommitteePerformance.tsx
@@ -10,6 +10,8 @@ import { useEffect, useState } from 'react';
 import { getCommitteeManagement } from '@polkadot/react-api/getCommitteeManagement';
 import { createNamedHook, useApi } from '@polkadot/react-hooks';
 
+import { removeDuplicates } from '../useSessionValidators.js';
+
 export interface ValidatorPerformance {
   accountId: string,
   blockCount?: number,
@@ -133,9 +135,11 @@ function useSessionCommitteePerformanceImpl (sessions: number[]): SessionCommitt
       const validatorsPromises = apis.map((api) => api.query.session.validators());
 
       Promise.all(validatorsPromises).then((validatorsOfValidators: Codec[][]) =>
-        setCommittees(validatorsOfValidators.map((validators) =>
-          validators.map((validator) => validator.toString()))))
-        .catch(console.error);
+        setCommittees(validatorsOfValidators.map((validators) => {
+          const accountIds = validators.map((validator) => validator.toString());
+
+          return removeDuplicates(accountIds);
+        }))).catch(console.error);
     }
     ).catch(console.error);
   },

--- a/packages/page-staking/src/Performance/useFinalityCommittee.ts
+++ b/packages/page-staking/src/Performance/useFinalityCommittee.ts
@@ -28,13 +28,11 @@ export const useFinalityCommittee = (session: number, currentSession: number): s
 };
 
 const getFinalityCommittee = async (session: number, api: ApiPromise) => {
-  const { firstBlockOfSelectedAuraSession, lastBlockOfPrecedingAlephBFTSession } = getBlocksImportantForSession(session, api);
+  const { lastBlockOfPrecedingAlephBFTSession } = getBlocksImportantForSession(session, api);
 
   const getFinalityCommittee: () => Promise<Vec<AccountId32>> = (
     // Committee must be set on the last block of the preceding session.
-    (await getApiAtBlock(lastBlockOfPrecedingAlephBFTSession, api)).query.aleph.nextFinalityCommittee ||
-    (await getApiAtBlock(firstBlockOfSelectedAuraSession, api)).query.session.validators
-  );
+    await getApiAtBlock(lastBlockOfPrecedingAlephBFTSession, api)).query.aleph.nextFinalityCommittee;
 
   return (await getFinalityCommittee()).map((accountId) => accountId.toHuman());
 };

--- a/packages/page-staking/src/index.tsx
+++ b/packages/page-staking/src/index.tsx
@@ -3,7 +3,7 @@
 
 import type { DeriveStakingOverview } from '@polkadot/api-derive/types';
 import type { AppProps as Props } from '@polkadot/react-components/types';
-import type { ElectionStatus, ParaValidatorIndex, ValidatorId } from '@polkadot/types/interfaces';
+import type { ElectionStatus } from '@polkadot/types/interfaces';
 import type { BN } from '@polkadot/util';
 
 import React, { useCallback, useMemo, useState } from 'react';
@@ -34,15 +34,12 @@ import useSortedTargets from './useSortedTargets.js';
 const HIDDEN_ACC = ['actions', 'payout'];
 
 const OPT_MULTI = {
-  defaultValue: [false, undefined, {}] as [boolean, BN | undefined, Record<string, boolean>],
-  transform: ([eraElectionStatus, minValidatorBond, validators, activeValidatorIndices]: [ElectionStatus | null, BN | undefined, ValidatorId[] | null, ParaValidatorIndex[] | null]): [boolean, BN | undefined, Record<string, boolean>] => [
+  defaultValue: [false, undefined] as [boolean, BN | undefined],
+  transform: ([eraElectionStatus, minValidatorBond]: [ElectionStatus | null, BN | undefined]): [boolean, BN | undefined] => [
     !!eraElectionStatus && eraElectionStatus.isOpen,
     minValidatorBond && !minValidatorBond.isZero()
       ? minValidatorBond
-      : undefined,
-    validators && activeValidatorIndices
-      ? activeValidatorIndices.reduce((all, index) => ({ ...all, [validators[index.toNumber()].toString()]: true }), {})
-      : {}
+      : undefined
   ]
 };
 
@@ -56,11 +53,9 @@ function StakingApp ({ basePath, className = '' }: Props): React.ReactElement<Pr
   const [loadNominations, setLoadNominations] = useState(false);
   const nominatedBy = useNominations(loadNominations);
   const stakingOverview = useCall<DeriveStakingOverview>(api.derive.staking.overview);
-  const [isInElection, minCommission] = useCallMulti<[boolean, BN | undefined, Record<string, boolean>]>([
+  const [isInElection, minCommission] = useCallMulti<[boolean, BN | undefined]>([
     api.query.staking.eraElectionStatus,
-    api.query.staking.minCommission,
-    api.query.session.validators,
-    (api.query.parasShared || api.query.shared)?.activeValidatorIndices
+    api.query.staking.minCommission
   ], OPT_MULTI);
   const ownPools = useOwnPools();
   const ownStashes = useOwnStashInfos();

--- a/packages/page-staking/src/useSessionValidators.ts
+++ b/packages/page-staking/src/useSessionValidators.ts
@@ -1,0 +1,42 @@
+// Copyright 2017-2025 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ApiPromise } from '@polkadot/api';
+import type { Codec } from '@polkadot/types/types';
+
+import { useMemo } from 'react';
+
+import { createNamedHook, useCall } from '@polkadot/react-hooks';
+
+// remove duplicates, this is identity mapping of there are no duplicates
+export function removeDuplicates (arr: string[]): string[] {
+  const map = new Map<string, boolean>();
+  const unique: string[] = [];
+
+  arr.forEach((item) => {
+    if (!map.has(item)) {
+      map.set(item, true);
+      unique.push(item);
+    }
+  });
+
+  return unique;
+}
+
+function useSessionValidatorsImpl (api: ApiPromise): string[] {
+  const sessionValidators = useCall<Codec[]>(api.query.session.validators);
+
+  return useMemo(() => {
+    if (sessionValidators) {
+      const validators = sessionValidators.map((validator) => validator.toString());
+
+      // in aleph-node v15 version, every block slot has assigned upfront validator
+      // hence, session.validators needs to be deduplicated
+      return removeDuplicates(validators);
+    }
+
+    return [];
+  }, [sessionValidators]);
+}
+
+export default createNamedHook('useSessionValidators', useSessionValidatorsImpl);


### PR DESCRIPTION
This change just deduplicates `session.validators` storage. It is required in v15 node, as that storage has 900 entries now - representing 900 slots. This PR does not affect v14 version, as deduplication does not affect `session.validators` order. 

Implementation is not ideal, as still there's some code duplication - ideally I'd like to see `api.query.session.vliadators`  only once in `page-staking`. 

Also, I analyzed if those v15 changes can impact other part of this repo, but they are not:
* apart `page-staking` there are no other usages of `api.query.session.vliadators`
* `api-derive` uses `api.query.session.vliadators`, but thankfully we don't use any of such calls