### PR TITLE
Support ABFT scores in Performance tab

### DIFF
--- a/packages/page-staking/src/Performance/FinalityCommittee.tsx
+++ b/packages/page-staking/src/Performance/FinalityCommittee.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2025 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { CardSummary, SummaryBox, Table } from '@polkadot/react-components';
 import { useNextTick } from '@polkadot/react-hooks';
@@ -33,32 +33,24 @@ function FinalityCommittee ({ className, currentSession, session }: Props) {
 
   const finalizers: Finalizer[] = useMemo(() => {
     if (finalityCommitteeAddresses?.length) {
-      return finalityCommitteeAddresses.map((accountId, index) => {
-        if (abftScores?.points.length === finalityCommitteeAddresses.length) {
-          return {
-            abftScore: abftScores.points.at(index)?.toNumber(),
-            accountId
-          };
-        }
-
-        return {
-          abftScore: undefined,
+      return finalityCommitteeAddresses.map((accountId, index) =>
+        ({
+          abftScore: abftScores?.points.at(index)?.toNumber(),
           accountId
-        };
-      });
+        })
+      );
     }
 
     return [];
   }, [abftScores, finalityCommitteeAddresses]
   );
 
-  const headerRef = useRef<[string, string, number?][]>(
+  const headerRef: [string, string, number?][] =
     [
       [t('finalizers'), 'start', 1],
       [t('ABFT score'), 'expand'],
       [t('stats'), 'expand']
-    ]
-  );
+    ];
 
   const list = useMemo(
     () => isNextTick
@@ -96,7 +88,7 @@ function FinalityCommittee ({ className, currentSession, session }: Props) {
             />
           </div>
         }
-        header={headerRef.current}
+        header={headerRef}
         legend={<Legend />}
       >
         {list.map(({ abftScore, accountId }): React.ReactNode => (

--- a/packages/page-staking/src/Performance/FinalityCommittee.tsx
+++ b/packages/page-staking/src/Performance/FinalityCommittee.tsx
@@ -1,23 +1,71 @@
 // Copyright 2017-2025 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import React from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 
-import { AddressSmall, CardSummary, SummaryBox, Table } from '@polkadot/react-components';
+import { CardSummary, SummaryBox, Table } from '@polkadot/react-components';
+import { useNextTick } from '@polkadot/react-hooks';
 
+import Filtering from '../Filtering.js';
 import { useTranslation } from '../translate.js';
+import FinalizerAddress from './FinalizerAddress/FinalizerAddress.js';
+import Legend from './Legend.js';
+import useAbftScores from './useAbftScores.js';
 import { useFinalityCommittee } from './useFinalityCommittee.js';
 
 interface Props {
+  className?: string;
   session: number;
   currentSession: number;
 }
 
-function FinalityCommittee ({ currentSession, session }: Props) {
+export interface Finalizer {
+  accountId: string;
+  abftScore?: number;
+}
+
+function FinalityCommittee ({ className, currentSession, session }: Props) {
   const { t } = useTranslation();
   const finalityCommitteeAddresses = useFinalityCommittee(session, currentSession);
+  const { abftScores, scoresEnabled } = useAbftScores(session);
+  const isNextTick = useNextTick();
+  const [nameFilter, setNameFilter] = useState<string>('');
 
-  const messageOnEmpty = finalityCommitteeAddresses && t("Data isn't available.");
+  const finalizers: Finalizer[] = useMemo(() => {
+    if (finalityCommitteeAddresses?.length) {
+      return finalityCommitteeAddresses.map((accountId, index) => {
+        if (abftScores?.points.length === finalityCommitteeAddresses.length) {
+          return {
+            abftScore: abftScores.points.at(index)?.toNumber(),
+            accountId
+          };
+        }
+
+        return {
+          abftScore: undefined,
+          accountId
+        };
+      });
+    }
+
+    return [];
+  }, [abftScores, finalityCommitteeAddresses]
+  );
+
+  const headerRef = useRef<[string, string, number?][]>(
+    [
+      [t('finalizers'), 'start', 1],
+      [t('ABFT score'), 'expand'],
+      [t('stats'), 'expand']
+    ]
+  );
+
+  const list = useMemo(
+    () => isNextTick
+      ? finalizers
+      : [],
+    [isNextTick, finalizers]
+  );
 
   return (
     <>
@@ -30,11 +78,35 @@ function FinalityCommittee ({ currentSession, session }: Props) {
           </CardSummary>
         </section>
       </SummaryBox>
-      <Table empty={messageOnEmpty}>
-        {finalityCommitteeAddresses?.map((address) => (
-          <tr key={address}>
-            <td><AddressSmall value={address} /></td>
-          </tr>
+      <Table
+        className={className}
+        empty={
+          list && t('No active finalizers found')
+        }
+        emptySpinner={
+          <>
+            {!finalizers && <div>{t('Retrieving finalizers')}</div>}
+          </>
+        }
+        filter={
+          <div className='staking--optionsBar'>
+            <Filtering
+              nameFilter={nameFilter}
+              setNameFilter={setNameFilter}
+            />
+          </div>
+        }
+        header={headerRef.current}
+        legend={<Legend />}
+      >
+        {list.map(({ abftScore, accountId }): React.ReactNode => (
+          <FinalizerAddress
+            abftScore={abftScore}
+            address={accountId}
+            filterName={nameFilter}
+            key={accountId}
+            scoresEnabled={scoresEnabled}
+          />
         ))}
       </Table>
     </>

--- a/packages/page-staking/src/Performance/FinalizerAddress/FinalizerAddress.tsx
+++ b/packages/page-staking/src/Performance/FinalizerAddress/FinalizerAddress.tsx
@@ -69,13 +69,13 @@ function FinalizerAddress ({ abftScore, address, filterName, scoresEnabled }: Pr
             hover={hoverText}
             icon={'check'}
           />}
-        {abftScore !== undefined && abftScore > 4 && abftScore < 11 &&
+        {abftScore !== undefined && abftScore > 4 && abftScore <= 11 &&
           <Badge
             color={'orange'}
             hover={hoverText}
             icon={'warning'}
           />}
-        {abftScore !== undefined && abftScore >= 11 &&
+        {abftScore !== undefined && abftScore > 11 &&
           <Badge
             color={'red'}
             hover={hoverText}

--- a/packages/page-staking/src/Performance/FinalizerAddress/FinalizerAddress.tsx
+++ b/packages/page-staking/src/Performance/FinalizerAddress/FinalizerAddress.tsx
@@ -1,0 +1,96 @@
+// Copyright 2017-2025 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ApiPromise } from '@polkadot/api';
+
+import React, { useCallback, useMemo } from 'react';
+
+import { AddressSmall, Badge, Icon } from '@polkadot/react-components';
+import { checkVisibility } from '@polkadot/react-components/util';
+import { useAddressToDomain, useApi, useDeriveAccountInfo } from '@polkadot/react-hooks';
+
+interface Props {
+  address: string;
+  filterName: string;
+  scoresEnabled: boolean;
+  abftScore?: number,
+}
+
+function useAddressCalls (_api: ApiPromise, address: string) {
+  const accountInfo = useDeriveAccountInfo(address);
+
+  return { accountInfo };
+}
+
+function queryAddress (address: string) {
+  window.location.hash = `/staking/query/${address}`;
+}
+
+function FinalizerAddress ({ abftScore, address, filterName, scoresEnabled }: Props): React.ReactElement<Props> | null {
+  const { api } = useApi();
+  const { accountInfo } = useAddressCalls(api, address);
+  const { primaryDomain: domain } = useAddressToDomain(address);
+
+  const isVisible = useMemo(
+    () => accountInfo ? checkVisibility(api, address, { ...accountInfo, domain }, filterName) : true,
+    [api, accountInfo, address, domain, filterName]
+  );
+
+  const onQueryStats = useCallback(
+    () => queryAddress(address),
+    [address]
+  );
+
+  const hoverText = useMemo(() => {
+    if (abftScore !== undefined) {
+      return abftScore === 1
+        ? '1 unit behind'
+        : `${abftScore} units behind`;
+    }
+
+    return null;
+  }, [abftScore]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <tr>
+      <td className='address'>
+        <AddressSmall value={address} />
+      </td>
+      <td className='number'>
+        {!scoresEnabled && 'scores are not enabled'}
+        {scoresEnabled && abftScore === undefined && 'scores not yet aggregated'}
+        {abftScore !== undefined && abftScore <= 4 &&
+          <Badge
+            color={'green'}
+            hover={hoverText}
+            icon={'check'}
+          />}
+        {abftScore !== undefined && abftScore > 4 && abftScore < 11 &&
+          <Badge
+            color={'orange'}
+            hover={hoverText}
+            icon={'warning'}
+          />}
+        {abftScore !== undefined && abftScore >= 11 &&
+          <Badge
+            color={'red'}
+            hover={hoverText}
+            icon={'skull'}
+          />}
+      </td>
+      <td className='number'>
+        <Icon
+          className='staking--stats highlight--color'
+          icon='chart-line'
+          onClick={onQueryStats}
+        />
+      </td>
+    </tr>
+  );
+}
+
+export default React.memo(FinalizerAddress);

--- a/packages/page-staking/src/Performance/FinalizerAddress/FinalizerAddress.tsx
+++ b/packages/page-staking/src/Performance/FinalizerAddress/FinalizerAddress.tsx
@@ -1,8 +1,6 @@
 // Copyright 2017-2025 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ApiPromise } from '@polkadot/api';
-
 import React, { useCallback, useMemo } from 'react';
 
 import { AddressSmall, Badge, Icon } from '@polkadot/react-components';
@@ -16,19 +14,13 @@ interface Props {
   abftScore?: number,
 }
 
-function useAddressCalls (_api: ApiPromise, address: string) {
-  const accountInfo = useDeriveAccountInfo(address);
-
-  return { accountInfo };
-}
-
 function queryAddress (address: string) {
   window.location.hash = `/staking/query/${address}`;
 }
 
 function FinalizerAddress ({ abftScore, address, filterName, scoresEnabled }: Props): React.ReactElement<Props> | null {
   const { api } = useApi();
-  const { accountInfo } = useAddressCalls(api, address);
+  const accountInfo = useDeriveAccountInfo(address);
   const { primaryDomain: domain } = useAddressToDomain(address);
 
   const isVisible = useMemo(

--- a/packages/page-staking/src/Performance/Legend.tsx
+++ b/packages/page-staking/src/Performance/Legend.tsx
@@ -18,7 +18,7 @@ function Legend ({ className }: Props): React.ReactElement<Props> {
           hover='no more than 4 units behind'
           icon='check'
         />
-        <span>{'Ideal performance'}</span>
+        <span>Ideal performance</span>
       </span>
       <span>
         <Badge
@@ -26,7 +26,7 @@ function Legend ({ className }: Props): React.ReactElement<Props> {
           hover='from 4 to 11 units behind'
           icon='warning'
         />
-        <span>{'acceptable performance'}</span>
+        <span>acceptable performance</span>
       </span>
       <span>
         <Badge
@@ -34,7 +34,7 @@ function Legend ({ className }: Props): React.ReactElement<Props> {
           hover='more than 11 units behind'
           icon='skull'
         />
-        <span>{'under-performance'}</span>
+        <span>under-performance</span>
       </span>
     </StyledDiv>
   );

--- a/packages/page-staking/src/Performance/Legend.tsx
+++ b/packages/page-staking/src/Performance/Legend.tsx
@@ -1,0 +1,65 @@
+// Copyright 2017-2025 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+import { Badge, styled } from '@polkadot/react-components';
+
+interface Props {
+  className?: string;
+}
+
+function Legend ({ className }: Props): React.ReactElement<Props> {
+  return (
+    <StyledDiv className={className}>
+      <span>
+        <Badge
+          color='green'
+          hover='no more than 4 units behind'
+          icon='check'
+        />
+        <span>{'Ideal performance'}</span>
+      </span>
+      <span>
+        <Badge
+          color='orange'
+          hover='from 4 to 11 units behind'
+          icon='warning'
+        />
+        <span>{'acceptable performance'}</span>
+      </span>
+      <span>
+        <Badge
+          color='red'
+          hover='more than 11 units behind'
+          icon='skull'
+        />
+        <span>{'under-performance'}</span>
+      </span>
+    </StyledDiv>
+  );
+}
+
+const StyledDiv = styled.div`
+  font-size: var(--font-size-small);
+  padding: 1rem 0.5rem;
+  text-align: center;
+
+  .ui--Badge, .ui--Tag {
+    margin-right: 0.5rem;
+  }
+
+  span {
+    vertical-align: middle;
+
+    * {
+      vertical-align: middle;
+    }
+
+    + span {
+      margin-left: 1rem;
+    }
+  }
+`;
+
+export default React.memo(Legend);

--- a/packages/page-staking/src/Performance/useAbftScores.tsx
+++ b/packages/page-staking/src/Performance/useAbftScores.tsx
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Option, Struct, Vec } from '@polkadot/types';
-import type { Hash, SessionIndex } from '@polkadot/types/interfaces';
+import type { SessionIndex } from '@polkadot/types/interfaces';
 import type { u16, u32 } from '@polkadot/types-codec';
 
 import { useEffect, useState } from 'react';
 
-import { getCommitteeManagement } from '@polkadot/react-api';
+import { getCommitteeManagement } from '@polkadot/react-api/getCommitteeManagement';
 import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 
 interface Score extends Struct {
@@ -26,31 +26,23 @@ const OPT_BOND = {
 function AbftScoresImpl (session: number) {
   const { api } = useApi();
 
-  const [firstBlockSessionHash, setFirstBlockSessionHash] = useState<Hash | undefined>(undefined);
   const [scoresEnabled, setScoresEnabled] = useState<boolean>(false);
   const sessionPeriod = Number(getCommitteeManagement(api).consts.sessionPeriod.toString());
 
   useEffect(() => {
     api.rpc.chain.getBlockHash(sessionPeriod * session + 1)
-      .then((blockHash) => setFirstBlockSessionHash(blockHash))
+      .then((firstBlockSessionHash) => {
+        api.at(firstBlockSessionHash.toString()).then((apiAtFirstBlock) => {
+          if (apiAtFirstBlock.query.aleph.abftScores !== undefined) {
+            apiAtFirstBlock.query.aleph.finalityVersion()
+              .then((finalityVersion) =>
+                setScoresEnabled(Number(finalityVersion.toString()) >= 5))
+              .catch(console.error);
+          }
+        }).catch(console.error);
+      })
       .catch(console.error);
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [api, session]
-  );
-
-  useEffect(() => {
-    if (firstBlockSessionHash) {
-      api.at(firstBlockSessionHash.toString()).then((apiAtFirstBlock) => {
-        if (apiAtFirstBlock.query.aleph.abftScores !== undefined) {
-          apiAtFirstBlock.query.aleph.finalityVersion()
-            .then((finalityVersion) =>
-              setScoresEnabled(Number(finalityVersion.toString()) >= 5))
-            .catch(console.error);
-        }
-      }).catch(console.error);
-    }
-  }, [api, firstBlockSessionHash]);
+  }, [api, session, sessionPeriod]);
 
   return {
     abftScores: useCall<Score | undefined>(scoresEnabled && api.query.aleph.abftScores, [session], OPT_BOND),

--- a/packages/page-staking/src/Performance/useAbftScores.tsx
+++ b/packages/page-staking/src/Performance/useAbftScores.tsx
@@ -1,0 +1,45 @@
+// Copyright 2017-2025 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Option, Struct, Vec } from '@polkadot/types';
+import type { SessionIndex } from '@polkadot/types/interfaces';
+import type { u16, u32 } from '@polkadot/types-codec';
+
+import { useEffect, useState } from 'react';
+
+import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
+
+interface Score extends Struct {
+  sessionId: SessionIndex,
+  nonce: u32,
+  points: Vec<u16>
+}
+
+const OPT_BOND = {
+  transform: (value: Option<Score>): Score | undefined =>
+    value.isSome
+      ? value.unwrap()
+      : undefined
+};
+
+function AbftScoresImpl (session: number) {
+  const { api } = useApi();
+
+  const [scoresEnabled, setScoresEnabled] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (api.query.aleph.abftScores !== undefined) {
+      api.query.aleph.finalityVersion()
+        .then((finalityVersion) =>
+          setScoresEnabled(finalityVersion.toString() === '5'))
+        .catch(console.error);
+    }
+  }, [api]);
+
+  return {
+    abftScores: useCall<Score | undefined>(scoresEnabled && api.query.aleph.abftScores, [session], OPT_BOND),
+    scoresEnabled
+  };
+}
+
+export default createNamedHook('AbftScores', AbftScoresImpl);

--- a/packages/page-staking/src/Performance/useCommitteePerformance.tsx
+++ b/packages/page-staking/src/Performance/useCommitteePerformance.tsx
@@ -15,6 +15,7 @@ import { removeDuplicates } from '../useSessionValidators.js';
 export interface ValidatorPerformance {
   accountId: string,
   blockCount?: number,
+  abftScore?: number,
 }
 
 export interface SessionCommitteePerformance {

--- a/packages/page-staking/src/Performance/useCommitteePerformance.tsx
+++ b/packages/page-staking/src/Performance/useCommitteePerformance.tsx
@@ -15,7 +15,6 @@ import { removeDuplicates } from '../useSessionValidators.js';
 export interface ValidatorPerformance {
   accountId: string,
   blockCount?: number,
-  abftScore?: number,
 }
 
 export interface SessionCommitteePerformance {


### PR DESCRIPTION
This PR supports ABFT scoring display in Perfomance tab, for current and past sessions. There are three scoring buckets - `ideal`, `acceptable` and `under-performance`, some hovers and legends, support for detecting of ABFT scoring is enabled on chain. 