### PR TITLE
Fix for suspensions started in era >= 1000

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@polkadot/api-augment": "^13.2.1",
     "@polkadot/api-base": "^13.2.1",
     "@polkadot/api-contract": "^13.2.1",
+    "@polkadot/api-derive@npm:13.2.1": "patch:@polkadot/api-derive@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-derive-npm-13.2.1-19d2cc1087.patch",
     "@polkadot/hw-ledger": "^13.1.1",
     "@polkadot/keyring": "^13.1.1",
     "@polkadot/networks": "^13.1.1",
@@ -123,7 +124,6 @@
     "@polkadot/x-textdecoder": "^13.1.1",
     "@polkadot/x-textencoder": "^13.1.1",
     "@polkadot/x-ws": "^13.1.1",
-    "typescript": "^5.3.3",
-    "@polkadot/api-derive@npm:13.2.1": "patch:@polkadot/api-derive@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-derive-npm-13.2.1-19d2cc1087.patch"
+    "typescript": "^5.3.3"
   }
 }

--- a/packages/page-staking/src/Suspensions/Suspensions.tsx
+++ b/packages/page-staking/src/Suspensions/Suspensions.tsx
@@ -1,7 +1,7 @@
 // Copyright 2017-2025 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { u64, Vec } from '@polkadot/types';
+import type { u8, u64, Vec } from '@polkadot/types';
 import type { EventRecord, Hash } from '@polkadot/types/interfaces';
 import type { Codec } from '@polkadot/types/types';
 import type { u32 } from '@polkadot/types-codec';
@@ -16,6 +16,16 @@ import useErasStartSessionIndexLookup from '../Performance/useErasStartSessionIn
 
 type SuspensionReasons = [string, string, number][];
 
+interface BanReason {
+  insufficientUptime?: u32,
+  otherReason?: Vec<u8>,
+}
+
+interface BanInfo {
+  reason: BanReason,
+  start: u32,
+}
+
 function parseEvents (events: EventRecord[]): SuspensionReasons {
   return events.filter(({ event }) => COMMITTEE_MANAGEMENT_NAMES.includes(event.section) && event.method === 'BanValidators')
     .map(({ event }) => {
@@ -23,21 +33,19 @@ function parseEvents (events: EventRecord[]): SuspensionReasons {
 
       const reasons: SuspensionReasons = raw.map((value) => {
         const account = value[0].toString();
-        const reasonAndEra = value[1].toHuman() as unknown as Record<string, Codec>;
+        const reasonAndEra = value[1].toJSON() as unknown as BanInfo;
 
-        const reasonTypeAndValue = reasonAndEra.reason as unknown as Record<string, string>;
-        const reasonType = Object.keys(reasonTypeAndValue)[0];
-        const reasonValue = Object.values(reasonTypeAndValue)[0];
+        const reasonTypeAndValue = reasonAndEra.reason;
         const era = Number(reasonAndEra.start.toString());
 
-        if (reasonType === 'OtherReason') {
-          return [account, reasonValue, era];
-        } else if (reasonType === 'InsufficientUptime') {
-          return [account, 'Insufficient uptime in at least ' + reasonValue + ' sessions', era];
+        if (reasonTypeAndValue.otherReason !== undefined) {
+          return [account, reasonTypeAndValue.otherReason.toString(), era];
+        } else if (reasonTypeAndValue.insufficientUptime !== undefined) {
+          return [account, 'Insufficient uptime in at least ' + reasonTypeAndValue.insufficientUptime.toString() + ' sessions', era];
         } else {
-          return [account, reasonType + ': ' + reasonValue, era];
+          return undefined;
         }
-      });
+      }).filter((reason) => reason !== undefined);
 
       return reasons;
     }).flat();

--- a/packages/page-staking/src/Suspensions/Suspensions.tsx
+++ b/packages/page-staking/src/Suspensions/Suspensions.tsx
@@ -33,19 +33,19 @@ function parseEvents (events: EventRecord[]): SuspensionReasons {
 
       const reasons: SuspensionReasons = raw.map((value) => {
         const account = value[0].toString();
-        const reasonAndEra = value[1].toJSON() as unknown as BanInfo;
+        const banInfo = value[1].toJSON() as unknown as BanInfo;
 
-        const reasonTypeAndValue = reasonAndEra.reason;
-        const era = Number(reasonAndEra.start.toString());
+        const reason = banInfo.reason;
+        const era = Number(banInfo.start.toString());
 
-        if (reasonTypeAndValue.otherReason !== undefined) {
-          return [account, reasonTypeAndValue.otherReason.toString(), era];
-        } else if (reasonTypeAndValue.insufficientUptime !== undefined) {
-          return [account, 'Insufficient uptime in at least ' + reasonTypeAndValue.insufficientUptime.toString() + ' sessions', era];
+        if (reason.otherReason !== undefined) {
+          return [account, reason.otherReason.toString(), era];
+        } else if (reason.insufficientUptime !== undefined) {
+          return [account, 'Insufficient uptime in at least ' + reason.insufficientUptime.toString() + ' sessions', era];
         } else {
-          return undefined;
+          return [account, 'Unknown ban reason', era];
         }
-      }).filter((reason) => reason !== undefined);
+      });
 
       return reasons;
     }).flat();


### PR DESCRIPTION
Fix for azero.dev bug, which occurs for eras >= 1000. Is caused by invalid to number cast. `toHuman` casts numbers with more than 4 digits using comma thousands separator, e.g. `1008` era is cast as `1,008`, which then `toNumber` was not able to handle. It was clear that suspensions was not correctly parsed, ie without explicit types. Now it should be better. See backend structs: https://github.com/Cardinal-Cryptography/aleph-node/blob/release-14/primitives/src/lib.rs#L246-L262

This change is dedicated for Mainnet and Testnet release, so it is based on `release-11` branch.