### PR TITLE
Added backwards compatibility for ban reasons from v14

### DIFF
--- a/packages/page-staking/src/Suspensions/Suspensions.tsx
+++ b/packages/page-staking/src/Suspensions/Suspensions.tsx
@@ -29,6 +29,7 @@ interface FinalityBanConfig {
 }
 
 interface BanReason {
+  insufficientUptime?: u32,
   insufficientProduction?: u32,
   insufficientFinalization?: u32,
   otherReason?: Vec<u8>,
@@ -64,6 +65,13 @@ function parseEvents (events: EventRecord[], productionBanConfigPeriod: number, 
             era,
             suspensionLiftsInEra: era + productionBanConfigPeriod,
             suspensionReason: `Insufficient block production in at least ${reason.insufficientProduction.toString()} sessions`
+          };
+        } else if (reason.insufficientUptime !== undefined) {
+          return {
+            address,
+            era,
+            suspensionLiftsInEra: era + productionBanConfigPeriod,
+            suspensionReason: `Insufficient block production in at least ${reason.insufficientUptime.toString()} sessions`
           };
         } else if (reason.insufficientFinalization !== undefined) {
           return {


### PR DESCRIPTION
This bugfix adds backward compatibility for `BanInfo` that still can be found in the storage.

It was tested with Testnet connected: 

![image](https://github.com/user-attachments/assets/6355dd98-baa3-4d51-8198-ea6b29c2cbf9)
