### PR TITLE
Applied a patch which sets page size to 25 in all RPC request

### DIFF
--- a/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch
+++ b/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch
@@ -1,0 +1,13 @@
+diff --git a/base/Decorate.js b/base/Decorate.js
+index 3aeb851111d8335fddd245f5bb3e9654c57ce53e..d18220a7de81d0962434ac8e06ef0de753c54d7f 100644
+--- a/base/Decorate.js
++++ b/base/Decorate.js
+@@ -14,7 +14,7 @@ import { Events } from './Events.js';
+ import { findCall, findError } from './find.js';
+ const PAGE_SIZE_K = 1000; // limit aligned with the 1k on the node (trie lookups are heavy)
+ const PAGE_SIZE_V = 250; // limited since the data may be > 16MB (e.g. misfiring elections)
+-const PAGE_SIZE_Q = 50; // queue of pending storage queries (mapped together, next tick)
++const PAGE_SIZE_Q = 25; // queue of pending storage queries (mapped together, next tick)
+ const l = logger('api/init');
+ let instanceCounter = 0;
+ function getAtQueryFn(api, { method, section }) {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "source-map-explorer": "^2.5.3"
   },
   "resolutions": {
-    "@polkadot/api": "^13.2.1",
     "@polkadot/api-augment": "^13.2.1",
     "@polkadot/api-base": "^13.2.1",
     "@polkadot/api-contract": "^13.2.1",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,15 @@
     "@polkadot/x-textdecoder": "^13.1.1",
     "@polkadot/x-textencoder": "^13.1.1",
     "@polkadot/x-ws": "^13.1.1",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "@polkadot/api@npm:13.2.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
+    "@polkadot/api@npm:^13.2.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
+    "@polkadot/api@npm:^4.2.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
+    "@polkadot/api@npm:latest": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
+    "@polkadot/api@npm:^9.14.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
+    "@polkadot/api@npm:^9.13.2": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
+    "@polkadot/api@npm:^10.9.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
+    "@polkadot/api@npm:^7.2.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
+    "@polkadot/api@npm:^10.10.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -123,15 +123,6 @@
     "@polkadot/x-textdecoder": "^13.1.1",
     "@polkadot/x-textencoder": "^13.1.1",
     "@polkadot/x-ws": "^13.1.1",
-    "typescript": "^5.3.3",
-    "@polkadot/api@npm:13.2.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
-    "@polkadot/api@npm:^13.2.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
-    "@polkadot/api@npm:^4.2.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
-    "@polkadot/api@npm:latest": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
-    "@polkadot/api@npm:^9.14.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
-    "@polkadot/api@npm:^9.13.2": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
-    "@polkadot/api@npm:^10.9.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
-    "@polkadot/api@npm:^7.2.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
-    "@polkadot/api@npm:^10.10.1": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch"
+    "@polkadot/api": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch"
   }
 }

--- a/packages/apps-config/package.json
+++ b/packages/apps-config/package.json
@@ -38,7 +38,7 @@
     "@peaqnetwork/type-definitions": "0.0.4",
     "@pendulum-chain/type-definitions": "0.3.8",
     "@phala/typedefs": "0.2.33",
-    "@polkadot/api": "^13.2.1",
+    "@polkadot/api": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
     "@polkadot/api-base": "^13.2.1",
     "@polkadot/api-derive": "patch:@polkadot/api-derive@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-derive-npm-13.2.1-19d2cc1087.patch",
     "@polkadot/networks": "^13.1.1",

--- a/packages/react-api/package.json
+++ b/packages/react-api/package.json
@@ -20,7 +20,7 @@
     "path": false
   },
   "dependencies": {
-    "@polkadot/api": "^13.2.1",
+    "@polkadot/api": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
     "@polkadot/extension-compat-metamask": "^0.53.1",
     "@polkadot/extension-dapp": "^0.53.1",
     "@polkadot/rpc-provider": "^13.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1990,7 +1990,7 @@ __metadata:
     "@peaqnetwork/type-definitions": "npm:0.0.4"
     "@pendulum-chain/type-definitions": "npm:0.3.8"
     "@phala/typedefs": "npm:0.2.33"
-    "@polkadot/api": "npm:^13.2.1"
+    "@polkadot/api": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch"
     "@polkadot/api-base": "npm:^13.2.1"
     "@polkadot/api-derive": "patch:@polkadot/api-derive@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-derive-npm-13.2.1-19d2cc1087.patch"
     "@polkadot/networks": "npm:^13.1.1"
@@ -2306,7 +2306,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@polkadot/react-api@workspace:packages/react-api"
   dependencies:
-    "@polkadot/api": "npm:^13.2.1"
+    "@polkadot/api": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch"
     "@polkadot/extension-compat-metamask": "npm:^0.53.1"
     "@polkadot/extension-dapp": "npm:^0.53.1"
     "@polkadot/rpc-provider": "npm:^13.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17334,6 +17334,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^3.9.7":
+  version: 3.9.10
+  resolution: "typescript@npm:3.9.10"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/f86a085eea24fdd665850c6be4dd69c7a71fe3d27ecc712be88cdc7a52d866f4f2416ad91c554df60f499dedcf288a24b3d8052e502833d8acc661a9d21bb98f
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^4.0.0, typescript@npm:^4.0.2, typescript@npm:^4.4.3, typescript@npm:^4.5.5, typescript@npm:^4.7.4":
+  version: 4.9.5
+  resolution: "typescript@npm:4.9.5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/458f7220ab11e0fc191514cc41be1707645ec9a8c2d609448a448e18c522cef9646f58728f6811185a4c35613dacdf6c98cf8965c88b3541d0288c47291e4300
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^5.3.3":
   version: 5.3.3
   resolution: "typescript@npm:5.3.3"
@@ -17341,6 +17361,26 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10/6e4e6a14a50c222b3d14d4ea2f729e79f972fa536ac1522b91202a9a65af3605c2928c4a790a4a50aa13694d461c479ba92cedaeb1e7b190aadaa4e4b96b8e18
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^3.9.7#optional!builtin<compat/typescript>":
+  version: 3.9.10
+  resolution: "typescript@patch:typescript@npm%3A3.9.10#optional!builtin<compat/typescript>::version=3.9.10&hash=3bd3d3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/77024c200e1f80d95185d5a973bcc4b0ecc12a77851390b1382e372195313769373a4b8b1642df4a8d4ae1df5911dcd9bde111cf6755eb4b6091f374e97c6dc5
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^4.0.0#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^4.0.2#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^4.4.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^4.5.5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^4.7.4#optional!builtin<compat/typescript>":
+  version: 4.9.5
+  resolution: "typescript@patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/5659316360b5cc2d6f5931b346401fa534107b68b60179cf14970e27978f0936c1d5c46f4b5b8175f8cba0430f522b3ce355b4b724c0ea36ce6c0347fab25afd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1420,7 +1420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:^13.2.1":
+"@polkadot/api@npm:13.2.1":
   version: 13.2.1
   resolution: "@polkadot/api@npm:13.2.1"
   dependencies:
@@ -1442,6 +1442,31 @@ __metadata:
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.7.0"
   checksum: 10/227ff33243450a5c3b173040228b0a457fdd93f4b07cc4abef15efc3f207b29ea3358e27ed510861050fb0e11c1c624bc5e6585a3780612f240746320dea5df2
+  languageName: node
+  linkType: hard
+
+"@polkadot/api@patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch":
+  version: 13.2.1
+  resolution: "@polkadot/api@patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch::version=13.2.1&hash=dd4935"
+  dependencies:
+    "@polkadot/api-augment": "npm:13.2.1"
+    "@polkadot/api-base": "npm:13.2.1"
+    "@polkadot/api-derive": "npm:13.2.1"
+    "@polkadot/keyring": "npm:^13.1.1"
+    "@polkadot/rpc-augment": "npm:13.2.1"
+    "@polkadot/rpc-core": "npm:13.2.1"
+    "@polkadot/rpc-provider": "npm:13.2.1"
+    "@polkadot/types": "npm:13.2.1"
+    "@polkadot/types-augment": "npm:13.2.1"
+    "@polkadot/types-codec": "npm:13.2.1"
+    "@polkadot/types-create": "npm:13.2.1"
+    "@polkadot/types-known": "npm:13.2.1"
+    "@polkadot/util": "npm:^13.1.1"
+    "@polkadot/util-crypto": "npm:^13.1.1"
+    eventemitter3: "npm:^5.0.1"
+    rxjs: "npm:^7.8.1"
+    tslib: "npm:^2.7.0"
+  checksum: 10/f51ada542cc4892256fa108a30432e52c26cfab9264a1f0c4943611642a22cd1e8d54327639fd6b83bae5dcaf1c11e20592bdf7dec6b0f8ee4737e188f0a57c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## tl;dr
Motivation is to make less RPC requests in a seconds when querying data from WS/RPC endpoint. 

## details
To what I checked empirically, this change does not effect loading time perceived by an user. The place it matters the most is Staking/Overview and Staking/Targets pages. There's this hook `useSortedTargets` that calls `state_subscribeStorage` multiple times, and now it does it with the 50 storage keys in the same request. As there's some kind of throttling in RPC node, sometimes it hits limit of requests in a second and RPC node does not respond, showing to the user this half-loaded staking data. With proposed 25, all data loads successfully. 

## how to check it worked

In browser developers tools -> Network -> Requests WS -> details -> see that requests how at most 25 keys

## patch
To generate this PR, I used commands:

```
yarn patch @polkadot/api
# edited the files in /tmp/xfs-b617dbdd/user
yarn patch-commit -s /tmp/xfs-b617dbdd/user
yarn install # updates yarn.lock
```