### PR TITLE
Decrease number of requests per second

### DIFF
--- a/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch
+++ b/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch
@@ -1,13 +1,15 @@
 diff --git a/base/Decorate.js b/base/Decorate.js
-index 3aeb851111d8335fddd245f5bb3e9654c57ce53e..d18220a7de81d0962434ac8e06ef0de753c54d7f 100644
+index 3aeb851111d8335fddd245f5bb3e9654c57ce53e..dc37bb2a6cd9491637f72c57d38356afb56a3114 100644
 --- a/base/Decorate.js
 +++ b/base/Decorate.js
-@@ -14,7 +14,7 @@ import { Events } from './Events.js';
+@@ -13,8 +13,8 @@ import { extractStorageArgs } from '../util/validate.js';
+ import { Events } from './Events.js';
  import { findCall, findError } from './find.js';
  const PAGE_SIZE_K = 1000; // limit aligned with the 1k on the node (trie lookups are heavy)
- const PAGE_SIZE_V = 250; // limited since the data may be > 16MB (e.g. misfiring elections)
+-const PAGE_SIZE_V = 250; // limited since the data may be > 16MB (e.g. misfiring elections)
 -const PAGE_SIZE_Q = 50; // queue of pending storage queries (mapped together, next tick)
-+const PAGE_SIZE_Q = 5; // queue of pending storage queries (mapped together, next tick)
++const PAGE_SIZE_V = 512; // limited since the data may be > 16MB (e.g. misfiring elections)
++const PAGE_SIZE_Q = 512; // queue of pending storage queries (mapped together, next tick)
  const l = logger('api/init');
  let instanceCounter = 0;
  function getAtQueryFn(api, { method, section }) {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "source-map-explorer": "^2.5.3"
   },
   "resolutions": {
+    "@polkadot/api": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch",
     "@polkadot/api-augment": "^13.2.1",
     "@polkadot/api-base": "^13.2.1",
     "@polkadot/api-contract": "^13.2.1",
@@ -123,7 +124,6 @@
     "@polkadot/x-textdecoder": "^13.1.1",
     "@polkadot/x-textencoder": "^13.1.1",
     "@polkadot/x-ws": "^13.1.1",
-    "typescript": "^5.3.3",
-    "@polkadot/api": "patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch"
+    "typescript": "^5.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1447,7 +1447,7 @@ __metadata:
 
 "@polkadot/api@patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch":
   version: 13.2.1
-  resolution: "@polkadot/api@patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch::version=13.2.1&hash=94a932"
+  resolution: "@polkadot/api@patch:@polkadot/api@npm%3A13.2.1#~/.yarn/patches/@polkadot-api-npm-13.2.1-ff35556ac0.patch::version=13.2.1&hash=f69e8d"
   dependencies:
     "@polkadot/api-augment": "npm:13.2.1"
     "@polkadot/api-base": "npm:13.2.1"
@@ -1466,7 +1466,7 @@ __metadata:
     eventemitter3: "npm:^5.0.1"
     rxjs: "npm:^7.8.1"
     tslib: "npm:^2.7.0"
-  checksum: 10/1bd2327a40524be11c058e625a48e025cb50da7f40cf0e238a563175063a862b3fc80709e603d059829a7e584684cdfa349b09d7a855271b29893b97df80e8ff
+  checksum: 10/f30bdb27230ed14c9e4b790bed3952361576b3192df645b21ba75d50a2c115d54d686c0b9928f79923d0440dccfd01fdd0103ffd684df93c6311bc01e53e8645
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a follow-up after change https://github.com/Cardinal-Cryptography/azero-dev/commit/e9bb66d63ed1fe7c8106881d50c1923153036436 which was in fact incorrect - instead of decreasing number of requests per seconds it actually increased it. What that change did was it decreased maximum request/response size of a single request. 

Since RPC node by default can withstand 15 MB of single RPC request/response, we can limit number of requests per second by making them larger. Empirically, one can check that with proposed 512 keys in a single `subscribeStorage` or `queryStorageAt`, we won't exceed 100kb per single request/response, which is significantly less anyway than limit of 15MB.

`PAGE_SIZE_Q` limits `subscribeStorage` max keys in a single request, and `PAGE_SIZE_K` limits `queryStorageAt` max keys in a single request, at least what I checked empirically. 

I tested this by connecting to the same azero.dev RPC node with current version and PR version - and latter was able to load Staking data while former was not. 

Kudos to @bartoszjedrzejewski who chased this issue and actually made me understand this issue correctly. 

`PAGE_SIZE_K` does not matter when loading Staking data - there are not many requests of such kind anyway.