### PR TITLE
Support manual unbans in suspensions tab.

### DIFF
--- a/packages/page-staking/src/Suspensions/Suspensions.tsx
+++ b/packages/page-staking/src/Suspensions/Suspensions.tsx
@@ -5,7 +5,9 @@ import type { u16, Vec } from '@polkadot/types';
 import type { EraIndex, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import type { Perbill } from '@polkadot/types/interfaces/runtime';
 import type { Codec } from '@polkadot/types/types';
+import type { SessionInfo } from '../Performance/useSessionInfo.js';
 import type { BanInfo, SuspensionEvent } from './index.js';
+import type { Banned } from './useBanned.js';
 
 import { useEffect, useMemo, useState } from 'react';
 
@@ -81,6 +83,16 @@ function parseEvents (events: EventRecord[], productionBanConfigPeriod: number, 
         }
       });
     }).flat();
+}
+
+function updateLiftEraForBansLiftedManually (eventsInBlocks: SuspensionEvent[], banned: Banned[], sessionInfo: SessionInfo) {
+  eventsInBlocks.forEach((eventInBlock) => {
+    if (banned.find((banned) => banned.account === eventInBlock.address) === undefined) {
+      if (eventInBlock.suspensionLiftsInEra > sessionInfo.currentEra) {
+        eventInBlock.suspensionLiftsInEra = sessionInfo.currentEra;
+      }
+    }
+  });
 }
 
 function useSuspensions (): SuspensionEvent[] | undefined {
@@ -161,12 +173,7 @@ function useSuspensions (): SuspensionEvent[] | undefined {
       return;
     }
 
-    eventsInBlocks.forEach((eventInBlock) => {
-      if (banned.find((banned) => banned.account === eventInBlock.address) === undefined) {
-        eventInBlock.suspensionLiftsInEra = sessionInfo.currentEra;
-      }
-    });
-
+    updateLiftEraForBansLiftedManually(eventsInBlocks, banned, sessionInfo);
     setSuspensionEvents(eventsInBlocks.reverse());
   },
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/page-staking/src/Suspensions/Suspensions.tsx
+++ b/packages/page-staking/src/Suspensions/Suspensions.tsx
@@ -86,12 +86,15 @@ function parseEvents (events: EventRecord[], productionBanConfigPeriod: number, 
 }
 
 function updateLiftEraForBansLiftedManually (eventsInBlocks: SuspensionEvent[], banned: Banned[], sessionInfo: SessionInfo) {
-  eventsInBlocks.forEach((eventInBlock) => {
-    if (banned.find((banned) => banned.account === eventInBlock.address) === undefined) {
-      if (eventInBlock.suspensionLiftsInEra > sessionInfo.currentEra) {
-        eventInBlock.suspensionLiftsInEra = sessionInfo.currentEra;
-      }
+  return eventsInBlocks.map((eventInBlock) => {
+    if (
+      banned.some((banned) => banned.account === eventInBlock.address) ||
+      eventInBlock.suspensionLiftsInEra <= sessionInfo.currentEra
+    ) {
+      return eventInBlock;
     }
+
+    return { ...eventInBlock, suspensionLiftsInEra: sessionInfo.currentEra };
   });
 }
 
@@ -173,8 +176,9 @@ function useSuspensions (): SuspensionEvent[] | undefined {
       return;
     }
 
-    updateLiftEraForBansLiftedManually(eventsInBlocks, banned, sessionInfo);
-    setSuspensionEvents(eventsInBlocks.reverse());
+    const updatedEvents = updateLiftEraForBansLiftedManually(eventsInBlocks, banned, sessionInfo);
+
+    setSuspensionEvents(updatedEvents.reverse());
   },
   // eslint-disable-next-line react-hooks/exhaustive-deps
   [api, JSON.stringify(eventsInBlocks), currentProductionBanPeriod]

--- a/packages/page-staking/src/Suspensions/Suspensions.tsx
+++ b/packages/page-staking/src/Suspensions/Suspensions.tsx
@@ -1,11 +1,11 @@
 // Copyright 2017-2025 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { u8, u16, u32, Vec } from '@polkadot/types';
+import type { u16, Vec } from '@polkadot/types';
 import type { EraIndex, EventRecord, Hash, SessionIndex } from '@polkadot/types/interfaces';
 import type { Perbill } from '@polkadot/types/interfaces/runtime';
 import type { Codec } from '@polkadot/types/types';
-import type { SuspensionEvent } from './index.js';
+import type { BanInfo, SuspensionEvent } from './index.js';
 
 import { useEffect, useMemo, useState } from 'react';
 
@@ -13,6 +13,8 @@ import { COMMITTEE_MANAGEMENT_NAMES, getCommitteeManagement } from '@polkadot/re
 import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
 
 import useErasStartSessionIndexLookup from '../Performance/useErasStartSessionIndexLookup.js';
+import useSessionInfo from '../Performance/useSessionInfo.js';
+import useBanned from './useBanned.js';
 
 interface ProductionBanConfig {
   minimalExpectedPerformance: Perbill,
@@ -26,17 +28,6 @@ interface FinalityBanConfig {
   underperformedSessionCountThreshold: SessionIndex,
   cleanSessionCounterDelay: SessionIndex,
   banPeriod: EraIndex,
-}
-
-interface BanReason {
-  insufficientUptime?: u32,
-  insufficientProduction?: u32,
-  insufficientFinalization?: u32,
-  otherReason?: Vec<u8>,
-}
-interface BanInfo {
-  reason: BanReason,
-  start: u32,
 }
 
 function parseEvents (events: EventRecord[], productionBanConfigPeriod: number, finalizationBanConfigPeriod: number): SuspensionEvent[] {
@@ -106,6 +97,9 @@ function useSuspensions (): SuspensionEvent[] | undefined {
   const finalityBanConfig = useCall<FinalityBanConfig>(getCommitteeManagement(api).query.finalityBanConfig);
   const currentFinalityBanPeriod = finalityBanConfig?.banPeriod;
 
+  const sessionInfo = useSessionInfo();
+  const banned = useBanned();
+
   const erasElectionsSessionIndexLookup = useMemo((): [number, number][] => {
     return erasStartSessionIndexLookup
       .filter(({ firstSession }) => firstSession > 0)
@@ -159,9 +153,19 @@ function useSuspensions (): SuspensionEvent[] | undefined {
   );
 
   useEffect(() => {
-    if (!currentProductionBanPeriod || !currentFinalityBanPeriod || !eventsInBlocks) {
+    if (currentProductionBanPeriod === undefined ||
+        currentFinalityBanPeriod === undefined ||
+        eventsInBlocks === undefined ||
+        banned === undefined ||
+        sessionInfo === undefined) {
       return;
     }
+
+    eventsInBlocks.forEach((eventInBlock) => {
+      if (banned.find((banned) => banned.account === eventInBlock.address) === undefined) {
+        eventInBlock.suspensionLiftsInEra = sessionInfo.currentEra;
+      }
+    });
 
     setSuspensionEvents(eventsInBlocks.reverse());
   },

--- a/packages/page-staking/src/Suspensions/index.tsx
+++ b/packages/page-staking/src/Suspensions/index.tsx
@@ -1,6 +1,9 @@
 // Copyright 2017-2025 @polkadot/app-staking authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { u8, u32, Vec } from '@polkadot/types';
+import type { Codec } from '@polkadot/types/types';
+
 import React from 'react';
 
 import { MarkWarning } from '@polkadot/react-components';
@@ -14,6 +17,17 @@ export interface SuspensionEvent {
   era: number;
   suspensionReason: string;
   suspensionLiftsInEra: number;
+}
+
+export interface BanReason extends Codec{
+  insufficientUptime?: u32,
+  insufficientProduction?: u32,
+  insufficientFinalization?: u32,
+  otherReason?: Vec<u8>,
+}
+export interface BanInfo extends Codec {
+  reason: BanReason,
+  start: u32,
 }
 
 function SuspensionsPage (): React.ReactElement {

--- a/packages/page-staking/src/Suspensions/useBanned.tsx
+++ b/packages/page-staking/src/Suspensions/useBanned.tsx
@@ -1,0 +1,43 @@
+// Copyright 2017-2025 @polkadot/app-staking authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AccountId32 } from '@polkadot/types/interfaces';
+import type { Option } from '@polkadot/types-codec';
+import type { BanInfo } from './index.js';
+
+import { useMemo } from 'react';
+
+import { createNamedHook, useApi, useCall } from '@polkadot/react-hooks';
+
+ type BannedEntry = [{ args: [AccountId32] }, Option<BanInfo>];
+
+export interface Banned {
+  readonly account: string,
+  readonly banInfo: BanInfo,
+}
+
+function useBannedImpl () {
+  const { api } = useApi();
+
+  const bannedStorageMap = useCall<BannedEntry[]>(api.query.committeeManagement.banned.entries);
+
+  return useMemo((): Banned[] | undefined => {
+    if (bannedStorageMap) {
+      return bannedStorageMap.filter(([, values]) => values.isSome)
+        .map(([key, values]) => {
+          const account = key.args[0].toString();
+
+          return {
+            account,
+            banInfo: values.unwrap()
+          };
+        });
+    }
+
+    return undefined;
+  },
+  [bannedStorageMap]
+  );
+}
+
+export default createNamedHook('useBanned', useBannedImpl);


### PR DESCRIPTION
azero.dev currently does not support manual unbanning

![image](https://github.com/user-attachments/assets/e85cedbc-6129-4188-9eb3-289f30a1e946)

Above 4 has been lifted recently in Mainnet, and there are currently still shown as banned, but they should not be on the list. In the fixed version, it looks like below:

![image](https://github.com/user-attachments/assets/ae4105e2-099e-4421-8d35-2a7acd4bb1d1)
